### PR TITLE
Check array type before assigning to graph attributes

### DIFF
--- a/glb/dataset.py
+++ b/glb/dataset.py
@@ -31,8 +31,7 @@ def node_classification_dataset_factory(graph: DGLGraph,
             self._g = graph
             for dataset_, indices_ in task.split.items():
                 assert not indices_.is_sparse
-                indices_ = torch.tensor(indices_.clone().detach()).to(
-                    self._g.device)
+                indices_ = indices_.to(self._g.device)
                 indices_ = torch.squeeze(indices_)
                 assert indices_.dim() == 1
                 if len(indices_) < self._g.num_nodes():  # index tensor

--- a/glb/graph.py
+++ b/glb/graph.py
@@ -40,7 +40,7 @@ def is_hetero_graph(data):
 def _to_tensor(x, device="cpu"):
     """Wrap x into a tensor."""
     if not torch.is_tensor(x) and sp.issparse(x):
-        x = sparse_to_torch(x, to_dense=True, device=device)
+        x = sparse_to_torch(x, to_dense=False, device=device)
     return x
 
 

--- a/glb/utils.py
+++ b/glb/utils.py
@@ -76,7 +76,7 @@ class KeyedFileReader():
 file_reader = KeyedFileReader()
 
 
-def sparse_to_torch(sparse_array: sp.spmatrix, to_dense=True, device="cpu"):
+def sparse_to_torch(sparse_array: sp.spmatrix, to_dense=False, device="cpu"):
     """Transform a sparse scipy array to sparse(coo) torch tensor.
 
     Note - add csr support.


### PR DESCRIPTION
This PR is to fix #44 

EDIT: glb will now check the sparsity of the input array, and transform it to a sparse CSR tensor if the input array is sparse.