### PR TITLE
Change `{split}_set` to `{split}_mask`

### DIFF
--- a/glb/dataset.py
+++ b/glb/dataset.py
@@ -53,7 +53,7 @@ def node_classification_dataset_factory(graph: DGLGraph,
                     mask = mask_list[0]
                 else:
                     mask = torch.stack(mask_list, dim=1)
-                self._g.ndata[dataset_] = mask.bool()
+                self._g.ndata[dataset_.replace("set", "mask")] = mask.bool()
 
         def __getitem__(self, idx):
             assert idx == 0, "This dataset has only one graph"


### PR DESCRIPTION
```python
>>> import glb
Using backend: pytorch
RDFLib Version: 5.0.0
>>> dataset = glb.dataloading.get_glb_dataset("cora", "task")
/home/jimmyzxj/glb/GLB-Repo/datasets/cora/cora.npz already exists.
/home/jimmyzxj/glb/GLB-Repo/datasets/cora/cora_task.npz already exists.
CORA dataset.
/home/jimmyzxj/glb/GLB-Repo/datasets/cora/cora.npz already exists.
/home/jimmyzxj/glb/GLB-Repo/datasets/cora/cora_task.npz already exists.
Node classification on CORA dataset. Planetoid split.
>>> g=dataset[0]
>>> g.ndata
{'NodeFeature': tensor(indices=tensor([[   0,    0,    0,  ..., 2707, 2707, 2707],
                       [  12,   41,   89,  ..., 1365, 1379, 1431]]),
       values=tensor([0.0385, 0.0385, 0.0385,  ..., 0.0526, 0.0526, 0.0526]),
       size=(2708, 1433), nnz=49216, layout=torch.sparse_coo), 'NodeLabel': tensor([4, 4, 4,  ..., 4, 3, 3]), 'train_mask': tensor([False, False, False,  ..., False, False, False]), 'val_mask': tensor([False, False,  True,  ..., False, False, False]), 'test_mask': tensor([ True,  True, False,  ..., False, False, False])}
>>> g.ndata.keys()
dict_keys(['NodeFeature', 'NodeLabel', 'train_mask', 'val_mask', 'test_mask'])
```

This PR is to fix #120 