### PR TITLE
Fix sparse to dense issue

### DIFF
--- a/glb/dataset.py
+++ b/glb/dataset.py
@@ -38,7 +38,7 @@ class NodeDataset(DGLDataset):
                 else:
                     indices_ = indices_list_[fold]
 
-                assert not indices_.is_sparse
+                assert not (indices_.is_sparse or indices_.is_sparse_csr)
                 indices_ = indices_.to(self._g.device)
                 indices_ = torch.squeeze(indices_)
                 assert indices_.dim() == 1
@@ -132,7 +132,7 @@ class GraphDataset(DGLDataset):
 
         device = self.graphs[0].device
         indices = self.task.split[self.split]
-        assert not indices.is_sparse
+        assert not (indices.is_sparse or indices.is_sparse_csr)
         if isinstance(indices, np.ndarray):
             indices = torch.from_numpy(indices).to(device)
         else:

--- a/glb/utils.py
+++ b/glb/utils.py
@@ -274,7 +274,7 @@ def _sparse_to_dense_safe(array: torch.Tensor):
     Returns:
         torch.Tensor: Dense tensor.
     """
-    if array.is_sparse:
+    if array.is_sparse or array.is_sparse_csr:
         array = array.to_dense()
         array_size = array.element_size() * array.nelement()
         if array_size > WARNING_DENSE_SIZE:


### PR DESCRIPTION
Fix #139.

The cause is that `torch.Tensor.is_sparse` is `true` only if the sparse tensor in coo format. We need to use `torch.Tensor.is_sparse` and `torch.Tensor.is_sparse_csr` to conclude if the tensor is sparse.