### PR TITLE
Add num_nodes in `dgl.graph()`

### DIFF
--- a/glb/graph.py
+++ b/glb/graph.py
@@ -129,7 +129,9 @@ def _get_homograph(data):
     src_nodes, dst_nodes = edges.T[0], edges.T[1]
     num_nodes = data["Graph"]["_NodeList"].shape[-1]
 
-    g: dgl.DGLGraph = dgl.graph((src_nodes, dst_nodes), num_nodes=num_nodes, device="cpu")
+    g: dgl.DGLGraph = dgl.graph((src_nodes, dst_nodes),
+                                num_nodes=num_nodes,
+                                device="cpu")
 
     for attr, array in data["Node"].items():
         g.ndata[attr] = _to_tensor(array)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add num_nodes in `dgl.graph()`


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#129 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Graph-Learning-Benchmarks/GLB-Repo/issues/129#issuecomment-1189758972

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my own machine:
```python
Python 3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:05:16)
[Clang 12.0.1 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import glb
>>> glb.dataloading.get_glb_graph("wiki")
/Users/jimmy/Projects/Private/GLB-Repo/datasets/wiki/wiki.npz already exists.
wiki dataset.
Graph(num_nodes=1925342, num_edges=303434860,
      ndata_schemes={'NodeFeature': Scheme(shape=(600,), dtype=torch.float32), 'NodeLabel': Scheme(shape=(), dtype=torch.int64)}
      edata_schemes={})
```
