### PR TITLE
Bring forward the reading order of the whole graph in multi-graph reading.

### DIFF
--- a/glb/graph.py
+++ b/glb/graph.py
@@ -86,12 +86,12 @@ def _get_single_graph(data, device="cpu", hetero=False):
 
 def _get_multi_graph(data, device="cpu"):
     """Initialize and return a list of Graph instance given data."""
+    # Extract the whole graph
+    g: dgl.DGLGraph = _get_single_graph(data)
+
     node_list = data["Graph"].pop("_NodeList")
     edge_list = data["Graph"].pop("_EdgeList", None)
     graphs = []
-
-    # Extract the whole graph
-    g: dgl.DGLGraph = _get_single_graph(data)
 
     # Check array type before assigning
     for attr, array in data["Node"].items():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bring forward the reading order of the whole graph in multi-graph reading.

## Description
<!--- Describe your changes in detail -->
When reading preserved attributes from the dictionary `data`, we will pop them out because they are not features of the graph(s). So `_NodeList` was popped out before reading the whole graph. Now we initialize the whole graph before popping out `_NodeList`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fix #155 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
$ python example.py --task GraphClassification
OGBg-molhiv dataset.
Processing graphs: 100%|████████████████| 41127/41127 [00:12<00:00, 3422.73it/s]
Read graph data from examples/ogbg-molhiv/metadata.json in 13.65s.
The task is to predict the target molecular properties as accurately as possible, where the molecular properties are cast as binary labels, e.g, whether a molecule inhibits HIV virus replication or not. Note that some datasets (e.g., ogbg-molpcba) can have multiple tasks, and can contain nan that indicates the corresponding label is not assigned to the molecule.
Read task specification from examples/ogbg-molhiv/task.json in 0.00s.
Combine graph and task into dataset(s) in 0.24s.
Peak memory usage: 440.25MB.
Dataset contains 41127 graphs.
cpu
<glb.task.GraphClassificationTask object at 0x12ce892e0>
[Dataset("The task is to predict the target molecular properties as accurately as possible, where the molecular properties are cast as binary labels, e.g, whether a molecule inhibits HIV virus replication or not. Note that some datasets (e.g., ogbg-molpcba) can have multiple tasks, and can contain nan that indicates the corresponding label is not assigned to the molecule.", num_graphs=32901, save_path=/Users/jimmy/.dgl/The task is to predict the target molecular properties as accurately as possible, where the molecular properties are cast as binary labels, e.g, whether a molecule inhibits HIV virus replication or not. Note that some datasets (e.g., ogbg-molpcba) can have multiple tasks, and can contain nan that indicates the corresponding label is not assigned to the molecule.), Dataset("The task is to predict the target molecular properties as accurately as possible, where the molecular properties are cast as binary labels, e.g, whether a molecule inhibits HIV virus replication or not. Note that some datasets (e.g., ogbg-molpcba) can have multiple tasks, and can contain nan that indicates the corresponding label is not assigned to the molecule.", num_graphs=4113, save_path=/Users/jimmy/.dgl/The task is to predict the target molecular properties as accurately as possible, where the molecular properties are cast as binary labels, e.g, whether a molecule inhibits HIV virus replication or not. Note that some datasets (e.g., ogbg-molpcba) can have multiple tasks, and can contain nan that indicates the corresponding label is not assigned to the molecule.), Dataset("The task is to predict the target molecular properties as accurately as possible, where the molecular properties are cast as binary labels, e.g, whether a molecule inhibits HIV virus replication or not. Note that some datasets (e.g., ogbg-molpcba) can have multiple tasks, and can contain nan that indicates the corresponding label is not assigned to the molecule.", num_graphs=4113, save_path=/Users/jimmy/.dgl/The task is to predict the target molecular properties as accurately as possible, where the molecular properties are cast as binary labels, e.g, whether a molecule inhibits HIV virus replication or not. Note that some datasets (e.g., ogbg-molpcba) can have multiple tasks, and can contain nan that indicates the corresponding label is not assigned to the molecule.)]
```