### PR TITLE
skip larger datasets: wiki, ogbg-code2

### DIFF
--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -12,6 +12,11 @@ def test_data_loading(dataset):
     Test if get_glb_graph, get_glb_task, and get_glb_dataset
     can be applied successfully.
     """
+    # temporary skipping all large datasets
+    large_dataset_to_skip = ["wiki", "ogbg-code2"]
+    if dataset in large_dataset_to_skip:
+        return
+
     directory = os.getcwd() + "/datasets/" + dataset
     task_list = []
     for file in os.listdir(directory):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Skip datasets: wiki, ogbg-code2 in testing for now, since they are too large. This feature need to be removed after the repo going public.

## Related Issue
[PR162 fails.](https://github.com/Graph-Learning-Benchmarks/GLB-Repo/pull/162)
[PR154 fails](https://github.com/Graph-Learning-Benchmarks/GLB-Repo/pull/154)


## How Has This Been Tested?
Locally, wiki can be skipped for testing successfully.
![image](https://user-images.githubusercontent.com/84695981/180162287-cbcbbed9-8676-4ea3-8c33-9f7123258ce5.png)
![image](https://user-images.githubusercontent.com/84695981/180162397-72eccc53-6720-49bd-a319-3de295b1d6c2.png)


