### PR TITLE
Fix format of task jsons of OpenKE datasets

### DIFF
--- a/datasets/FB13/task_predict_entity.json
+++ b/datasets/FB13/task_predict_entity.json
@@ -6,7 +6,7 @@
         "file": "FB13.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "FB13.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/FB13/task_predict_relation.json
+++ b/datasets/FB13/task_predict_relation.json
@@ -6,7 +6,7 @@
         "file": "FB13.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "FB13.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/FB15K/task_predict_entity.json
+++ b/datasets/FB15K/task_predict_entity.json
@@ -6,7 +6,7 @@
         "file": "FB15K.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "FB15K.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/FB15K/task_predict_relation.json
+++ b/datasets/FB15K/task_predict_relation.json
@@ -6,7 +6,7 @@
         "file": "FB15K.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "FB15K.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/FB15K237/task_predict_entity.json
+++ b/datasets/FB15K237/task_predict_entity.json
@@ -6,7 +6,7 @@
         "file": "FB15K237237.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "FB15K237237.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/FB15K237/task_predict_relation.json
+++ b/datasets/FB15K237/task_predict_relation.json
@@ -6,7 +6,7 @@
         "file": "FB15K237237.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "FB15K237237.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/NELL-995/task_predict_entity.json
+++ b/datasets/NELL-995/task_predict_entity.json
@@ -6,7 +6,7 @@
         "file": "NELL-995.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "NELL-995.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/NELL-995/task_predict_relation.json
+++ b/datasets/NELL-995/task_predict_relation.json
@@ -6,7 +6,7 @@
         "file": "NELL-995.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "NELL-995.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/WN11/task_predict_entity.json
+++ b/datasets/WN11/task_predict_entity.json
@@ -6,7 +6,7 @@
         "file": "WN11.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "WN11.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/WN11/task_predict_relation.json
+++ b/datasets/WN11/task_predict_relation.json
@@ -6,7 +6,7 @@
         "file": "WN11.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "WN11.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/WN18/task_predict_entity.json
+++ b/datasets/WN18/task_predict_entity.json
@@ -6,7 +6,7 @@
         "file": "WN18.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "WN18.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/WN18/task_predict_relation.json
+++ b/datasets/WN18/task_predict_relation.json
@@ -6,7 +6,7 @@
         "file": "WN18.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "WN18.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/WN18RR/task_predict_entity.json
+++ b/datasets/WN18RR/task_predict_entity.json
@@ -6,7 +6,7 @@
         "file": "WN18RR.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "WN18RR.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/WN18RR/task_predict_relation.json
+++ b/datasets/WN18RR/task_predict_relation.json
@@ -6,7 +6,7 @@
         "file": "WN18RR.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "WN18RR.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/YAGO3-10/task_predict_entity.json
+++ b/datasets/YAGO3-10/task_predict_entity.json
@@ -6,7 +6,7 @@
         "file": "YAGO3-10.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "YAGO3-10.npz",
         "key": "ValidEdge_id"
     },

--- a/datasets/YAGO3-10/task_predict_relation.json
+++ b/datasets/YAGO3-10/task_predict_relation.json
@@ -6,7 +6,7 @@
         "file": "YAGO3-10.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "YAGO3-10.npz",
         "key": "ValidEdge_id"
     },

--- a/examples/WN18RR/task_predict_entity.json
+++ b/examples/WN18RR/task_predict_entity.json
@@ -6,7 +6,7 @@
         "file": "WN18RR.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "WN18RR.npz",
         "key": "ValidEdge_id"
     },

--- a/examples/WN18RR/task_predict_relation.json
+++ b/examples/WN18RR/task_predict_relation.json
@@ -6,7 +6,7 @@
         "file": "WN18RR.npz",
         "key": "TrainEdge_id"
     },
-    "valid_triplet_set": {
+    "val_triplet_set": {
         "file": "WN18RR.npz",
         "key": "ValidEdge_id"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

1. Added the required `feature` attribute in all the task json files of OpenKE datasets and set the value as `null`. 
2. Changed all the `valid_*` attributes to `val_*` to make the name convention consistent with `NodeClassification` and `GraphClassification` tasks.

PS: The task loaders for these two link prediction tasks have not been implemented so no change in code is made (FYI, @xingjian-zhang).

List of modified files:
- datasets/FB13/task_predict_entity.json
- datasets/FB13/task_predict_relation.json
- datasets/FB15K/task_predict_entity.json
- datasets/FB15K/task_predict_relation.json
- datasets/FB15K237/task_predict_entity.json
- datasets/FB15K237/task_predict_relation.json
- datasets/NELL-995/task_predict_entity.json
- datasets/NELL-995/task_predict_relation.json
- datasets/WN11/task_predict_entity.json
- datasets/WN11/task_predict_relation.json
- datasets/WN18/task_predict_entity.json
- datasets/WN18/task_predict_relation.json
- datasets/WN18RR/task_predict_entity.json
- datasets/WN18RR/task_predict_relation.json
- datasets/YAGO3-10/task_predict_entity.json
- datasets/YAGO3-10/task_predict_relation.json
- examples/WN18RR/task_predict_entity.json
- examples/WN18RR/task_predict_relation.json

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#165 for `feature` and #166 for `val_*`.

