### PR TITLE
Change 'valid_' to 'val_' for TimeDependentLinkPrediction tasks

### DIFF
--- a/examples/ogbl-collab/task_prestore_neg.json
+++ b/examples/ogbl-collab/task_prestore_neg.json
@@ -6,7 +6,7 @@
         "Edge/EdgeWeight"
     ],
     "time": "Edge/EdgeYear",
-    "valid_neg": {
+    "val_neg": {
         "file": "ogbl-collab_task_prestore_neg.npz",
         "key": "val_neg"
     },
@@ -15,6 +15,6 @@
         "key": "test_neg"
     },
     "train_time_window": [1963, 2018],
-    "valid_time_window": [2018, 2019],
+    "val_time_window": [2018, 2019],
     "test_time_window": [2019, 2020]
 }

--- a/examples/ogbl-collab/task_runtime_sampling.json
+++ b/examples/ogbl-collab/task_runtime_sampling.json
@@ -7,6 +7,6 @@
     ],
     "time": "Edge/EdgeYear",
     "train_time_window": [1963, 2018],
-    "valid_time_window": [2018, 2019],
+    "val_time_window": [2018, 2019],
     "test_time_window": [2019, 2020]
 }

--- a/glb/dataset.py
+++ b/glb/dataset.py
@@ -211,7 +211,7 @@ class TimeDependentLinkPredictionDataset(DGLDataset):
         assert time_entries[0] == "Edge"
         time_attr = time_entries[-1]
         etime = self._g.edata[time_attr]  # tensor / dict of tensor
-        for split in ["train", "valid", "test"]:
+        for split in ["train", "val", "test"]:
             window = self.task.time_window[f"{split}_time_window"]
             if isinstance(etime, dict):
                 self._g.edata[f"{split}_mask"] = {
@@ -229,7 +229,7 @@ class TimeDependentLinkPredictionDataset(DGLDataset):
             Dict: split_dict
         """
         split_dict = {}
-        for split in ["train", "valid", "test"]:
+        for split in ["train", "val", "test"]:
             split_dict[split] = torch.masked_select(
                 torch.arange(self._g.num_edges()),
                 self._g.edata[f"{split}_mask"])

--- a/glb/task.py
+++ b/glb/task.py
@@ -164,9 +164,9 @@ class LinkPredictionTask(GLBTask):
     def __init__(self, task_dict, pwd):
         """Link/Edge prediction."""
         self.target = "Edge/_Edge"
-        self.valid_neg = task_dict.get("valid_neg", None)
+        self.val_neg = task_dict.get("val_neg", None)
         self.test_neg = task_dict.get("test_neg", None)
-        self.sample_runtime = self.valid_neg is not None
+        self.sample_runtime = self.val_neg is not None
         super().__init__(task_dict, pwd)
 
     pass
@@ -180,13 +180,13 @@ class TimeDependentLinkPredictionTask(LinkPredictionTask):
         self.time = task_dict["time"]
         self.time_window = {
             "train_time_window": task_dict["train_time_window"],
-            "valid_time_window": task_dict["valid_time_window"],
+            "val_time_window": task_dict["val_time_window"],
             "test_time_window": task_dict["test_time_window"]
         }
         super().__init__(task_dict, pwd)
 
     def _load(self, task_dict):
-        for neg_idx in ["valid_neg", "test_neg"]:
+        for neg_idx in ["val_neg", "test_neg"]:
             if getattr(self, neg_idx, None):
                 filename = task_dict[neg_idx]["file"]
                 key = task_dict[neg_idx].get("key")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changed all `valid_*` to `val_*` for `TimeDependentLinkPrediction` tasks (at this stage, there is only one dataset, `ogbl-collab`, in /examples). Also made changes accordingly in dataloader.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#166

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on my local machine (need to copy obgl-collab from /examples to /datasets).

<img width="574" alt="image" src="https://user-images.githubusercontent.com/5397179/180813047-a6a9e857-caa1-4472-a60f-0e556e06c3e8.png">
