### PR TITLE
add config

### DIFF
--- a/benchmarks/NodeClassification/config.py
+++ b/benchmarks/NodeClassification/config.py
@@ -1,0 +1,223 @@
+"""
+Config for GLB.
+
+References:
+https://github.com/pyg-team/pytorch_geometric/blob/575611f4f5e2209c7923dba977a1eebc207bd2e2/torch_geometric/graphgym/config.py
+"""
+
+import os
+import shutil
+import warnings
+
+
+try:  # Define global config object
+    from yacs.config import CfgNode as CN
+    CFG = CN()
+except ImportError:
+    CFG = None
+    warnings.warn("Could not define global config object. Please install "
+                  "'yacs' for using the GraphGym experiment manager via "
+                  "'pip install yacs'.")
+
+
+def set_cfg(cfg):
+    """
+    Set the default config value.
+
+    1) Note that for an experiment, only part of the arguments will be used
+    The remaining unused arguments won't affect anything.
+    So feel free to register any argument in graphgym.contrib.config
+    2) We support *at most* two levels of configs, e.g., cfg.dataset.name
+    :return: configuration use by the experiment.
+    """
+    if cfg is None:
+        return cfg
+
+    # ----------------------------------------------------------------------- #
+    # Basic options
+    # ----------------------------------------------------------------------- #
+
+    # Output directory
+    cfg.out_dir = "results"
+
+    # Config name (in out_dir)
+    cfg.cfg_dest = "config.yaml"
+
+    # ----------------------------------------------------------------------- #
+    # Globally shared variables:
+    # These variables will be set dynamically based on the input dataset
+    # Do not directly set them here or in .yaml files
+    # ----------------------------------------------------------------------- #
+
+    cfg.share = CN()
+
+    # Size of input dimension
+    cfg.share.dim_in = 1
+
+    # Size of out dimension, i.e., number of labels to be predicted
+    cfg.share.dim_out = 1
+
+    # Number of dataset splits: train/val/test
+    cfg.share.num_splits = 1
+
+    # ----------------------------------------------------------------------- #
+    # Dataset options
+    # ----------------------------------------------------------------------- #
+    cfg.dataset = CN()
+
+    # Name of the dataset
+    cfg.dataset.name = "cora"
+
+    # Whether add self loop
+    cfg.dataset.self_loop = 1
+
+    # Whether transform the dataset to dense
+    cfg.dataset.to_dense = 0
+
+    # if PyG: look for it in Pytorch Geometric dataset
+    # if NetworkX/nx: load data in NetworkX format
+    cfg.dataset.format = "PyG"
+
+    # Dir to load the dataset. If the dataset is downloaded, this is the
+    # cache dir
+    cfg.dataset.dir = "./datasets"
+
+    # Task: node, edge, graph, link_pred
+    cfg.dataset.task = "node"
+
+    # Type of task: classification, regression, classification_binary
+    # classification_multi
+    cfg.dataset.task_type = "classification"
+
+    # ----------------------------------------------------------------------- #
+    # Training options
+    # ----------------------------------------------------------------------- #
+    cfg.train = CN()
+
+    # Skip re-evaluate the validation set
+    cfg.train.fastmode = False
+
+    # ----------------------------------------------------------------------- #
+    # Model options
+    # ----------------------------------------------------------------------- #
+    cfg.model = CN()
+
+    # Number of hidden layers
+    cfg.model.num_layers = 2
+
+    # Number of hidden units
+    cfg.model.num_hidden = 8
+
+    # Number of hidden attention heads"
+    cfg.model.num_heads = 8
+
+    # Number of output attention heads
+    cfg.model.num_out_heads = 2
+
+    # Whether to use residual connection
+    cfg.model.residual = False
+
+    # Dropout rate
+    cfg.model.dropout = 0.6
+
+    # The negative slope of leaky relu
+    cfg.model.Negative_slope = 0.2
+
+    # Pseudo coordinate dimensions in GMMConv
+    cfg.model.pseudo_dim = 2
+
+    # Number of kernels in GMMConv layer
+    cfg.model.num_kernels = 3
+
+    # Aggregator type: mean/gcn/pool/lstm
+    cfg.model.aggregator_type = "gcn"
+
+    # Loss function: cross_entropy, mse
+    cfg.model.loss_fun = "cross_entropy"
+
+    # ----------------------------------------------------------------------- #
+    # Optimizer options
+    # ----------------------------------------------------------------------- #
+    cfg.optim = CN()
+
+    # optimizer: sgd, adam
+    cfg.optim.optimizer = "adam"
+
+    # Base learning rate
+    cfg.optim.lr = 0.01
+
+    # L2 regularization
+    cfg.optim.weight_decay = 5e-4
+
+    # Maximal number of epochs
+    cfg.optim.max_epoch = 2000
+
+
+def load_cfg(cfg, args):
+    """
+    Load configurations from file system and command line.
+
+    Args:
+        cfg (CfgNode): Configuration node
+        args (ArgumentParser): Command argument parser
+
+    """
+    cfg.merge_from_file(args.cfg_file)
+    cfg.merge_from_list(args.opts)
+
+
+def makedirs_rm_exist(dirt):
+    """Make directory."""
+    if os.path.isdir(dirt):
+        shutil.rmtree(dirt)
+    os.makedirs(dirt, exist_ok=True)
+
+
+def get_fname(fname):
+    """
+    Extract filename from file name path.
+
+    Args:
+        fname (string): Filename for the yaml format configuration file
+    """
+    fname = fname.split("/")[-1]
+    if fname.endswith(".yaml"):
+        fname = fname[:-5]
+    elif fname.endswith(".yml"):
+        fname = fname[:-4]
+    return fname
+
+
+def set_out_dir(out_dir, fname):
+    """
+    Create the directory for full experiment run.
+
+    Args:
+        out_dir (string): Directory for output, specified in :obj:`cfg.out_dir`
+        fname (string): Filename for the yaml format configuration file
+
+    """
+    fname = get_fname(fname)
+    CFG.out_dir = os.path.join(out_dir, fname)
+    # Make output directory
+    makedirs_rm_exist(CFG.out_dir)
+
+
+def set_run_dir(out_dir):
+    """
+    Create the directory for each random seed experiment run.
+
+    Args:
+        out_dir (string): Directory for output, specified in :obj:`cfg.out_dir`
+        fname (string): Filename for the yaml format configuration file
+
+    """
+    CFG.run_dir = os.path.join(out_dir, str(CFG.seed))
+    # Make output directory
+    if CFG.train.auto_resume:
+        os.makedirs(CFG.run_dir, exist_ok=True)
+    else:
+        makedirs_rm_exist(CFG.run_dir)
+
+
+set_cfg(CFG)

--- a/benchmarks/NodeClassification/configs/example_node.yaml
+++ b/benchmarks/NodeClassification/configs/example_node.yaml
@@ -1,0 +1,23 @@
+out_dir: results
+dataset:
+  self_loop: 1
+  to_dense: 1
+model:
+  loss_fun: cross_entropy
+  num_layers: 2
+  num_hidden: 8
+  num_heads: 8
+  num_out_heads: 2
+  residual: False
+  dropout: .6
+  Negative_slope: .2
+  pseudo_dim: 2
+  num_kernels: 3
+  aggregator_type: gcn
+train:
+  fastmode: False
+optim:
+  optimizer: adam
+  lr: .005
+  max_epoch: 2000
+  weight_decay: 5e-4

--- a/benchmarks/NodeClassification/utils.py
+++ b/benchmarks/NodeClassification/utils.py
@@ -1,4 +1,15 @@
-"""Utility functions."""
+"""
+Utility functions.
+
+References:
+https://github.com/pyg-team/pytorch_geometric/blob/
+575611f4f5e2209c7923dba977a1eebc207bd2e2/torch_geometric/
+graphgym/cmd_args.py
+"""
+import argparse
+import errno
+import os
+import os.path as osp
 import torch.nn.functional as F
 from models.gcn import GCN
 from models.gat import GAT
@@ -7,53 +18,93 @@ from models.graph_sage import GraphSAGE
 from models.mlp import MLP
 
 
-def generate_model(args, g, in_feats, n_classes):
+Models_need_to_be_densed = ["MoNet", "GAT"]
+
+
+def generate_model(cfg, g, in_feats, n_classes):
     """Generate required model."""
     # create model
-    if args.model == "GCN":
+    if cfg.model.name == "GCN":
         model = GCN(g,
                     in_feats,
-                    args.num_hidden,
+                    cfg.model.num_hidden,
                     n_classes,
-                    args.num_layers,
+                    cfg.model.num_layers,
                     F.relu,
-                    args.in_drop)
-    elif args.model == "GAT":
-        heads = ([args.num_heads] * (args.num_layers-1)) + [args.num_out_heads]
+                    cfg.model.dropout)
+    elif cfg.model.name == "GAT":
+        heads = ([cfg.model.num_heads] * (cfg.model.num_layers-1))\
+                + [cfg.model.num_out_heads]
         model = GAT(g,
-                    args.num_layers,
+                    cfg.model.num_layers,
                     in_feats,
-                    args.num_hidden,
+                    cfg.model.num_hidden,
                     n_classes,
                     heads,
                     F.elu,
-                    args.in_drop,
-                    args.attn_drop,
-                    args.negative_slope,
-                    args.residual)
-    elif args.model == "MoNet":
+                    cfg.model.dropout,
+                    cfg.model.dropout,
+                    cfg.model.Negative_slope,
+                    cfg.model.residual)
+    elif cfg.model.name == "MoNet":
         model = MoNet(g,
                       in_feats,
-                      args.num_hidden,
+                      cfg.model.num_hidden,
                       n_classes,
-                      args.num_layers,
-                      args.pseudo_dim,
-                      args.num_kernels,
-                      args.in_drop)
-    elif args.model == "GraphSAGE":
+                      cfg.model.num_layers,
+                      cfg.model.pseudo_dim,
+                      cfg.model.num_kernels,
+                      cfg.model.dropout)
+    elif cfg.model.name == "GraphSAGE":
         model = GraphSAGE(g,
                           in_feats,
-                          args.num_hidden,
+                          cfg.model.num_hidden,
                           n_classes,
-                          args.num_layers,
+                          cfg.model.num_layers,
                           F.relu,
-                          args.in_drop,
-                          args.aggregator_type)
-    elif args.model == "MLP":
+                          cfg.model.dropout,
+                          cfg.model.aggregator_type)
+    elif cfg.model.name == "MLP":
         model = MLP(in_feats,
-                    args.num_hidden,
+                    cfg.model.num_hidden,
                     n_classes,
-                    args.num_layers,
+                    cfg.model.num_layers,
                     F.relu,
-                    args.in_drop)
+                    cfg.model.in_drop)
     return model
+
+
+def makedirs(path: str):
+    r"""Recursive directory creation function."""
+    try:
+        os.makedirs(osp.expanduser(osp.normpath(path)))
+    except OSError as e:
+        if e.errno != errno.EEXIST and osp.isdir(path):
+            raise e
+
+
+def parse_args():
+    """Parse the command line arguments."""
+    parser = argparse.ArgumentParser(description="train for node\
+                                                  classification")
+    parser.add_argument("--cfg", dest="cfg_file", type=str, required=True,
+                        help="The configuration file path.")
+    parser.add_argument("--repeat", type=int, default=1,
+                        help="The number of repeated jobs.")
+    parser.add_argument("--mark_done", action="store_true",
+                        help="Mark yaml as done after a job has finished.")
+    parser.add_argument("opts", default=None, nargs=argparse.REMAINDER,
+                        help="See graphgym/config.py for remaining options.")
+    parser.add_argument("--model", type=str, default="GCN",
+                        help="model to be used. GCN, GAT, MoNet,\
+                              GraphSAGE, MLP for now")
+    parser.add_argument("--dataset", type=str, default="cora",
+                        help="dataset to be trained")
+    parser.add_argument("--task", type=str,
+                        default="task",
+                        help="task name for NodeClassification,")
+    parser.add_argument("--gpu", type=int, default=-1,
+                        help="which GPU to use. Set -1 to use CPU.")
+    parser.add_argument("--epochs", type=int, default=200,
+                        help="number of training epochs")
+    return parser.parse_args()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add configuration to allow putting in parameters through yaml files

## Related Issue
Now we don't have long list of argprasers.
But one drawback is that: all the parameters that are going to appear in yaml files need to be stated in the `config.py` during initialization.


## How Has This Been Tested?
Now all the datasets can be trained on all models (except wiki).
For example, `python3 train.py --cfg ./configs/example_node.yaml  --model GAT  --dataset cora`

## Screenshots (if appropriate):
Example logs:
```
Namespace(cfg_file='./configs/example_node.yaml', repeat=1, mark_done=False, opts=[], model='MoNet', dataset='chameleon', task='task', gpu=-1, epochs=50)
cfg_dest: config.yaml
dataset:
  dir: ./datasets
  format: PyG
  name: cora
  self_loop: 1
  task: node
  task_type: classification
  to_dense: 1
model:
  Negative_slope: 0.2
  aggregator_type: gcn
  dropout: 0.6
  loss_fun: cross_entropy
  num_heads: 8
  num_hidden: 8
  num_kernels: 3
  num_layers: 2
  num_out_heads: 2
  pseudo_dim: 2
  residual: False
optim:
  lr: 0.005
  max_epoch: 2000
  optimizer: adam
  weight_decay: 0.0005
out_dir: results/example_node
share:
  dim_in: 1
  dim_out: 1
  num_splits: 1
train:
  fastmode: False
/home/huangjin/GLB-Repo/datasets/chameleon/chameleon.npz already exists.
/home/huangjin/GLB-Repo/datasets/chameleon/chameleon_task.npz already exists.
Chameleon dataset.
/home/huangjin/GLB-Repo/datasets/chameleon/chameleon.npz already exists.
/home/huangjin/GLB-Repo/datasets/chameleon/chameleon_task.npz already exists.
Node classification on Chameleon dataset. The split is introduced in the paper "Multi-scale Attributed Node Embedding", while the classification categories are introduced in the paper "Geom-GCN: Geometric Graph Convolutional Networks".
----Data statistics------'
      #Edges 38328
      #Classes 5
      #Train samples 1092
      #Val samples 729
      #Test samples 456
MoNet(
  (layers): ModuleList(
    (0): GMMConv(
      (fc): Linear(in_features=2325, out_features=24, bias=False)
    )
    (1): GMMConv(
      (fc): Linear(in_features=8, out_features=24, bias=False)
    )
    (2): GMMConv(
      (fc): Linear(in_features=8, out_features=15, bias=False)
    )
  )
  (pseudo_proj): ModuleList(
    (0): Sequential(
      (0): Linear(in_features=2, out_features=2, bias=True)
      (1): Tanh()
    )
    (1): Sequential(
      (0): Linear(in_features=2, out_features=2, bias=True)
      (1): Tanh()
    )
    (2): Sequential(
      (0): Linear(in_features=2, out_features=2, bias=True)
      (1): Tanh()
    )
  )
  (dropout): Dropout(p=0.6, inplace=False)
)
Epoch 00000 | Time(s) nan| Loss 4655.8755 | TrainAcc 0.2335 | ValAcc 0.2469 | ETputs(KTEPS) nan
Epoch 00001 | Time(s) nan| Loss 54621.4727 | TrainAcc 0.2207 | ValAcc 0.2510 | ETputs(KTEPS) nan
Epoch 00002 | Time(s) nan| Loss 36270.7578 | TrainAcc 0.1978 | ValAcc 0.1920 | ETputs(KTEPS) nan
Epoch 00003 | Time(s) 1.2952| Loss 36678.6406 | TrainAcc 0.2234 | ValAcc 0.1879 | ETputs(KTEPS) 29.59
Epoch 00004 | Time(s) 2.1728| Loss 42372.8555 | TrainAcc 0.2005 | ValAcc 0.2030 | ETputs(KTEPS) 17.64
Epoch 00005 | Time(s) 2.3946| Loss 51659.6211 | TrainAcc 0.2573 | ValAcc 0.2565 | ETputs(KTEPS) 16.01
Epoch 00006 | Time(s) 2.5586| Loss 37231.2578 | TrainAcc 0.2363 | ValAcc 0.2936 | ETputs(KTEPS) 14.98
Epoch 00007 | Time(s) 2.6228| Loss 29099.9883 | TrainAcc 0.2445 | ValAcc 0.3155 | ETputs(KTEPS) 14.61
Epoch 00008 | Time(s) 2.6942| Loss 15657.5352 | TrainAcc 0.2399 | ValAcc 0.2853 | ETputs(KTEPS) 14.23
Epoch 00009 | Time(s) 2.7446| Loss 20542.8242 | TrainAcc 0.2125 | ValAcc 0.2689 | ETputs(KTEPS) 13.97
Epoch 00010 | Time(s) 2.7685| Loss 15731.7822 | TrainAcc 0.2564 | ValAcc 0.2565 | ETputs(KTEPS) 13.84
Epoch 00011 | Time(s) 2.7979| Loss 10562.6025 | TrainAcc 0.2473 | ValAcc 0.2675 | ETputs(KTEPS) 13.70
Epoch 00012 | Time(s) 2.8229| Loss 15684.7031 | TrainAcc 0.2216 | ValAcc 0.2785 | ETputs(KTEPS) 13.58
Epoch 00013 | Time(s) 2.8421| Loss 11294.7715 | TrainAcc 0.2271 | ValAcc 0.2730 | ETputs(KTEPS) 13.49
Epoch 00014 | Time(s) 2.8603| Loss 10808.1963 | TrainAcc 0.2399 | ValAcc 0.2881 | ETputs(KTEPS) 13.40
Epoch 00015 | Time(s) 2.8738| Loss 13935.3828 | TrainAcc 0.2198 | ValAcc 0.2579 | ETputs(KTEPS) 13.34
Epoch 00016 | Time(s) 2.8847| Loss 9961.6230 | TrainAcc 0.2344 | ValAcc 0.2455 | ETputs(KTEPS) 13.29
Epoch 00017 | Time(s) 2.8559| Loss 12413.4131 | TrainAcc 0.2665 | ValAcc 0.2483 | ETputs(KTEPS) 13.42
Epoch 00018 | Time(s) 2.8675| Loss 11314.4502 | TrainAcc 0.2619 | ValAcc 0.2620 | ETputs(KTEPS) 13.37
Epoch 00019 | Time(s) 2.8789| Loss 6840.7427 | TrainAcc 0.2335 | ValAcc 0.2634 | ETputs(KTEPS) 13.31
Epoch 00020 | Time(s) 2.8892| Loss 6855.4595 | TrainAcc 0.2335 | ValAcc 0.2565 | ETputs(KTEPS) 13.27
Epoch 00021 | Time(s) 2.8974| Loss 12530.7432 | TrainAcc 0.2427 | ValAcc 0.2387 | ETputs(KTEPS) 13.23
Epoch 00022 | Time(s) 2.9044| Loss 6298.9194 | TrainAcc 0.2408 | ValAcc 0.2455 | ETputs(KTEPS) 13.20
Epoch 00023 | Time(s) 2.9113| Loss 4237.1597 | TrainAcc 0.2445 | ValAcc 0.2428 | ETputs(KTEPS) 13.17
Epoch 00024 | Time(s) 2.9170| Loss 5451.1177 | TrainAcc 0.2500 | ValAcc 0.2538 | ETputs(KTEPS) 13.14
Epoch 00025 | Time(s) 2.9224| Loss 2432.1145 | TrainAcc 0.2674 | ValAcc 0.2579 | ETputs(KTEPS) 13.12
Epoch 00026 | Time(s) 2.9277| Loss 2810.9897 | TrainAcc 0.2546 | ValAcc 0.2524 | ETputs(KTEPS) 13.09
Epoch 00027 | Time(s) 2.9320| Loss 2480.7029 | TrainAcc 0.2766 | ValAcc 0.2483 | ETputs(KTEPS) 13.07
Epoch 00028 | Time(s) 2.9018| Loss 2939.0798 | TrainAcc 0.2637 | ValAcc 0.2524 | ETputs(KTEPS) 13.21
Epoch 00029 | Time(s) 2.9074| Loss 2635.4312 | TrainAcc 0.2482 | ValAcc 0.2565 | ETputs(KTEPS) 13.18
Epoch 00030 | Time(s) 2.9124| Loss 4711.5220 | TrainAcc 0.2537 | ValAcc 0.2497 | ETputs(KTEPS) 13.16
Epoch 00031 | Time(s) 2.9169| Loss 6110.2476 | TrainAcc 0.2619 | ValAcc 0.2538 | ETputs(KTEPS) 13.14
Epoch 00032 | Time(s) 2.9208| Loss 3118.7297 | TrainAcc 0.2546 | ValAcc 0.2483 | ETputs(KTEPS) 13.12
Epoch 00033 | Time(s) 2.9246| Loss 3481.5959 | TrainAcc 0.2601 | ValAcc 0.2483 | ETputs(KTEPS) 13.11
Epoch 00034 | Time(s) 2.9281| Loss 2844.6533 | TrainAcc 0.2482 | ValAcc 0.2551 | ETputs(KTEPS) 13.09
Epoch 00035 | Time(s) 2.9313| Loss 3873.8970 | TrainAcc 0.2473 | ValAcc 0.2455 | ETputs(KTEPS) 13.08
Epoch 00036 | Time(s) 2.9347| Loss 3481.8274 | TrainAcc 0.2546 | ValAcc 0.2455 | ETputs(KTEPS) 13.06
Epoch 00037 | Time(s) 2.9381| Loss 3368.7864 | TrainAcc 0.2381 | ValAcc 0.2579 | ETputs(KTEPS) 13.05
Epoch 00038 | Time(s) 2.9410| Loss 3406.7061 | TrainAcc 0.2610 | ValAcc 0.2675 | ETputs(KTEPS) 13.03
Epoch 00039 | Time(s) 2.9427| Loss 1951.0897 | TrainAcc 0.2665 | ValAcc 0.2606 | ETputs(KTEPS) 13.02
Epoch 00040 | Time(s) 2.9456| Loss 3189.5017 | TrainAcc 0.2647 | ValAcc 0.2620 | ETputs(KTEPS) 13.01
Epoch 00041 | Time(s) 2.9482| Loss 3515.4834 | TrainAcc 0.2747 | ValAcc 0.2593 | ETputs(KTEPS) 13.00
Epoch 00042 | Time(s) 2.9505| Loss 2057.0901 | TrainAcc 0.2738 | ValAcc 0.2442 | ETputs(KTEPS) 12.99
Epoch 00043 | Time(s) 2.9524| Loss 7090.4683 | TrainAcc 0.2912 | ValAcc 0.2455 | ETputs(KTEPS) 12.98
Epoch 00044 | Time(s) 2.9543| Loss 1964.8386 | TrainAcc 0.2592 | ValAcc 0.2277 | ETputs(KTEPS) 12.97
Epoch 00045 | Time(s) 2.9562| Loss 2453.4722 | TrainAcc 0.3068 | ValAcc 0.2305 | ETputs(KTEPS) 12.97
Epoch 00046 | Time(s) 2.9579| Loss 4398.4854 | TrainAcc 0.2830 | ValAcc 0.2305 | ETputs(KTEPS) 12.96
Epoch 00047 | Time(s) 2.9598| Loss 4514.2217 | TrainAcc 0.2701 | ValAcc 0.2332 | ETputs(KTEPS) 12.95
Epoch 00048 | Time(s) 2.9615| Loss 3352.5867 | TrainAcc 0.2509 | ValAcc 0.2332 | ETputs(KTEPS) 12.94
Epoch 00049 | Time(s) 2.9634| Loss 3800.9915 | TrainAcc 0.2647 | ValAcc 0.2277 | ETputs(KTEPS) 12.93
```