### PR TITLE
Fix #178

### DIFF
--- a/examples/ogbl-collab/ogbl-collab.ipynb
+++ b/examples/ogbl-collab/ogbl-collab.ipynb
@@ -2,26 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 81,
    "id": "15c565ab",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using backend: pytorch[21:05:45] /opt/dgl/src/runtime/tensordispatch.cc:43: TensorDispatcher: dlopen failed: /home/jimmyzxj/miniconda3/envs/py39/lib/python3.9/site-packages/dgl/tensoradapter/pytorch/libtensoradapter_pytorch_1.10.2.so: cannot open shared object file: No such file or directory\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# source: https://ogb.stanford.edu/docs/linkprop/#ogbl-collab\n",
     "import numpy as np\n",
+    "import torch\n",
     "from ogb.linkproppred import LinkPropPredDataset\n",
     "\n",
     "dataset = LinkPropPredDataset(name = 'ogbl-collab')\n",
@@ -33,53 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "4c3a04c9",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "node_feats = graph['node_feat'] # (235868, 128)\n",
-    "edge_year = graph['edge_year']\n",
-    "edge_weight = graph['edge_weight'].reshape(-1,) # (2358104, )\n",
-    "edge = graph['edge_index'].T # (2358104, 2)\n",
-    "neg_edge = np.concatenate([valid_edge['edge_neg'], test_edge['edge_neg']])\n",
-    "node_list = np.ones((1, graph['num_nodes']))\n",
-    "edge_list = np.ones((1, edge.shape[0]))\n",
-    "edge_id = np.arange(0, edge.shape[0])\n",
-    "\n",
-    "data = {\n",
-    "    \"node_feats\": node_feats,\n",
-    "    \"edge_year\": edge_year,\n",
-    "    \"edge_weight\":edge_weight,\n",
-    "    \"edge\": edge,\n",
-    "    \"neg_edge\": neg_edge,\n",
-    "    \"node_list\": node_list,\n",
-    "    \"edge_list\": edge_list,\n",
-    "    \"edge_id\": edge_id\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "44979c00",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "np.savez_compressed(\"ogbl-collab.npz\", **data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "id": "2ffbbf14",
    "metadata": {
     "pycharm": {
@@ -91,59 +37,132 @@
     "task_data = {\n",
     "    # use edges (N, 2) to save negative edges\n",
     "    \"val_neg\": valid_edge['edge_neg'],\n",
-    "    \"test_neg\": test_edge['edge_neg'],\n",
-    "    \"train_time_window\": (1963, 2017),\n",
-    "    \"valid_time_window\": (2018, 2018),\n",
-    "    \"test_time_window\": (2019, 2019)\n",
+    "    \"test_neg\": test_edge['edge_neg']\n",
     "}\n",
-    "np.savez_compressed(\"ogbl-collab_task_prestore_neg.npz\", **task_data)\n",
-    "\n",
-    "\n"
+    "np.savez_compressed(\"ogbl-collab_task_prestore_neg.npz\", **task_data)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "366dccf3",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "task_data_no_pre_stored_neg_edge = {\n",
-    "    \"train_time_window\": (1963, 2017), # window of (edge_year in train)\n",
-    "    \"valid_time_window\": (2018, 2018),\n",
-    "    \"test_time_window\": (2019, 2019)\n",
-    "}\n",
-    "np.savez_compressed(\"ogbl-collab_task_runtime_sampling.npz\", **task_data_no_pre_stored_neg_edge)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "90e5abd0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# 1. pre-store neg - index\n",
-    "# 2. no pre-store - time"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 83,
    "id": "aacaeea4",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
+   "outputs": [],
+   "source": [
+    "edges = train_edge\n",
+    "for e in (valid_edge, test_edge):\n",
+    "    for t in (\"edge\", \"weight\", \"year\"):\n",
+    "        edges[t] = np.concatenate((edges[t], e[t]))\n",
+    "\n",
+    "\n",
+    "import dgl\n",
+    "g = dgl.graph((edges[\"edge\"].T[0], edges[\"edge\"].T[1]))\n",
+    "g.edata[\"weight\"] = torch.from_numpy(edges[\"weight\"])\n",
+    "g.edata[\"year\"] = torch.from_numpy(edges[\"year\"])\n",
+    "g.ndata[\"feat\"] = torch.from_numpy(graph[\"node_feat\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "id": "94fbccc3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[150989, 224881],\n",
+       "        [150989, 224881],\n",
+       "        [180078, 199043],\n",
+       "        ...,\n",
+       "        [ 47058, 190305],\n",
+       "        [216257, 190305],\n",
+       "        [ 32459, 190305]])"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.stack(g.edges()).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "4c3a04c9",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "node_feats = graph['node_feat'] # (235868, 128)\n",
+    "edge_year = g.edata[\"year\"].numpy()\n",
+    "edge_weight = g.edata[\"weight\"].numpy() # (2358104, )\n",
+    "edge = torch.stack(g.edges()).T.numpy() # (2358104, 2)\n",
+    "node_list = np.ones((1, graph['num_nodes']))\n",
+    "edge_list = np.ones((1, edge.shape[0]))\n",
+    "edge_id = np.arange(0, edge.shape[0])\n",
+    "\n",
+    "data = {\n",
+    "    \"node_feats\": node_feats,\n",
+    "    \"edge_year\": edge_year,\n",
+    "    \"edge_weight\":edge_weight,\n",
+    "    \"edge\": edge,\n",
+    "    \"node_list\": node_list,\n",
+    "    \"edge_list\": edge_list,\n",
+    "    \"edge_id\": edge_id\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "id": "9767d935",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "node_feats (235868, 128)\n",
+      "edge_year (1285465,)\n",
+      "edge_weight (1285465,)\n",
+      "edge (1285465, 2)\n",
+      "node_list (1, 235868)\n",
+      "edge_list (1, 1285465)\n",
+      "edge_id (1285465,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for k, v in data.items():\n",
+    "    print(k, v.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "id": "988ba8cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.savez_compressed(\"ogbl-collab.npz\", **data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40c83914",
+   "metadata": {},
    "outputs": [],
    "source": []
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Combines all train, valid, test edges into a single graph for `ogbl-collab`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fix #178

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
Python 3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:05:16) 
[Clang 12.0.1 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import glb
>>> graph = glb.dataloading.read_glb_graph("examples/ogbl-collab/metadata.json")
>>> task = glb.dataloading.read_glb_task("examples/ogbl-collab/task_prestore_neg.json")
>>> dataset = glb.dataloading.combine_graph_and_task(graph, task)
>>> print(dataset[0].edata["test_mask"])
tensor([False, False, False,  ...,  True,  True,  True])
```
