### PR TITLE
Fix ogbn-mag urls

### DIFF
--- a/examples/ogbn-mag/urls.json
+++ b/examples/ogbn-mag/urls.json
@@ -1,4 +1,4 @@
 {
 	"ogbn-mag.npz": "https://www.dropbox.com/s/ivubg9csuq74oon/ogbn-mag__ogbn-mag.npz?dl=0",
-	"ogbn-mag_task.npz": "https://www.dropbox.com/s/ft2ycu9xftp4966/ogbn-mag__ogbn-mag_task.npz?dl=0",
+	"ogbn-mag_task.npz": "https://www.dropbox.com/s/ft2ycu9xftp4966/ogbn-mag__ogbn-mag_task.npz?dl=0"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the redundant comma in urls.json in `examples/ogbn-mag` that causes loading error.
