### PR TITLE
Remove GLBDataset class

### DIFF
--- a/glb/dataset.py
+++ b/glb/dataset.py
@@ -13,20 +13,7 @@ from glb.task import (KGEntityPredictionTask, GLBTask, GraphClassificationTask,
                       TimeDependentLinkPredictionTask)
 
 
-class GLBDataset(DGLDataset):
-    """GLB dataset base class."""
-
-    def __init__(self, task: GLBTask):
-        """Initialize the dataset with basic task info."""
-        self.features = task.features
-        self.target = task.target
-        self.num_splits = task.num_splits
-        self.split = task.split
-
-        super().__init__(name=task.description, force_reload=True)
-
-
-class NodeDataset(GLBDataset):
+class NodeDataset(DGLDataset):
     """Node level dataset."""
 
     def __init__(self, graph: DGLGraph, task: GLBTask):
@@ -134,7 +121,7 @@ class NodeRegressionDataset(NodeDataset):
         super().__init__(graph, task)
 
 
-class GraphDataset(GLBDataset):
+class GraphDataset(DGLDataset):
     """Graph Dataset."""
 
     def __init__(self,
@@ -223,7 +210,7 @@ class GraphRegressionDataset(GraphDataset):
         super().__init__(graphs, task, split)
 
 
-class EdgeDataset(GLBDataset):
+class EdgeDataset(DGLDataset):
     """Edge level dataset."""
 
     def __init__(self, graph: DGLGraph, task: GLBTask):
@@ -277,10 +264,8 @@ class LinkPredictionDataset(EdgeDataset):
             DGLGraph: train_g
         """
         train_g = self._g.clone()
-        non_train_edges = torch.cat((
-            self.split["val_set"],
-            self.split["test_set"]
-        ))
+        non_train_edges = torch.cat(
+            (self.split["val_set"], self.split["test_set"]))
         train_g.remove_edges(non_train_edges)
         for split in ("train", "val", "test"):
             train_g.edata.pop(f"{split}_mask")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the class `GLBDataset`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
The previous merge conflict leads to a runtime error. This pr is to resolve the error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
(glb) jimmy in ~/Projects/Private/GLB-Repo on main ● λ python example.py -g examples/ogbn-mag/metadata.json -t examples/ogbn-mag/task.json -v
OGBN-MAG dataset.
> Graph(s) loading takes 2.8898 seconds and uses 1045.7684 MB.
The ogbn-mag dataset is a heterogeneous network composed of a subset of the Microsoft Academic Graph (MAG) [1]. It contains four types of entities—papers (736,389 nodes), authors (1,134,649 nodes), institutions (8,740 nodes), and fields of study (59,965 nodes)—as well as four types of directed relations connecting two types of entities—an author is “affiliated with” an institution, an author “writes” a paper, a paper “cites” a paper, and a paper “has a topic of” a field of study. Similar to ogbn-mag, each paper is associated with a 128-dimensional word2vec feature vector, and all the other types of entities are not associated with input node features.
> Task loading takes 0.0154 seconds and uses 6.1901 MB.
> Combining(s) graph and task takes 0.0000 seconds and uses 0.0021 MB.
Traceback (most recent call last):
  File "example.py", line 105, in <module>
    main()
  File "example.py", line 77, in main
    dataset = glb.dataloading.combine_graph_and_task(g, task)
  File "/Users/jimmy/Projects/Private/GLB-Repo/glb/dataloading.py", line 29, in combine_graph_and_task
    return glb.dataset.node_dataset_factory(graph, task)
  File "/Users/jimmy/Projects/Private/GLB-Repo/glb/dataset.py", line 360, in node_dataset_factory
    return NodeClassificationDataset(graph, task)
  File "/Users/jimmy/Projects/Private/GLB-Repo/glb/dataset.py", line 120, in __init__
    super().__init__(graph, task)
  File "/Users/jimmy/Projects/Private/GLB-Repo/glb/dataset.py", line 47, in __init__
    super().__init__(name=f"{self._g.name} {task.type}", force_reload=True)
TypeError: __init__() got an unexpected keyword argument 'name'
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
(glb) jimmy in ~/Projects/Private/GLB-Repo on main ● λ python example.py -g examples/ogbn-mag/metadata.json -t examples/ogbn-mag/task.json -v
OGBN-MAG dataset.
> Graph(s) loading takes 2.9772 seconds and uses 1045.7676 MB.
The ogbn-mag dataset is a heterogeneous network composed of a subset of the Microsoft Academic Graph (MAG) [1]. It contains four types of entities—papers (736,389 nodes), authors (1,134,649 nodes), institutions (8,740 nodes), and fields of study (59,965 nodes)—as well as four types of directed relations connecting two types of entities—an author is “affiliated with” an institution, an author “writes” a paper, a paper “cites” a paper, and a paper “has a topic of” a field of study. Similar to ogbn-mag, each paper is associated with a 128-dimensional word2vec feature vector, and all the other types of entities are not associated with input node features.
> Task loading takes 0.0133 seconds and uses 6.1900 MB.
> Combining(s) graph and task takes 0.0189 seconds and uses 0.0129 MB.
Dataset("OGBN-MAG dataset. NodeClassification", num_graphs=1, save_path=/Users/jimmy/.dgl/OGBN-MAG dataset. NodeClassification)
```
