### PR TITLE
Fix graph-level dataset loading error

### DIFF
--- a/glb/dataset.py
+++ b/glb/dataset.py
@@ -150,7 +150,8 @@ class GraphDataset(DGLDataset):
             raise NotImplementedError(
                 "GraphDataset does not support multi-split.")
 
-        super().__init__(name=f"{self.graphs[0].name} {task.type}", force_reload=True)
+        super().__init__(name=f"{self.graphs[0].name} {task.type}",
+                         force_reload=True)
 
     def process(self):
         """Add train, val, and test masks to graph."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The previous merge conflict led to some members of `GraphDataset` were not initialized correctly. I added these members back.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Graph-Learning-Benchmarks/GLB-Repo/runs/7751852971?check_suite_focus=true#logs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
λ python example.py -g ogbg-molfreesolv -t ogbg-molfreesolv_task
Processing graphs: 100%|█████████████████████████████████████████████████████████████████████████████████| 642/642 [00:00<00:00, 3025.46it/s]
> Graph(s) loading takes 0.2613 seconds and uses 4.2340 MB.
> Task loading takes 0.0031 seconds and uses 0.1156 MB.
> Combining(s) graph and task takes 0.0067 seconds and uses 0.0680 MB.
[Dataset("ogbg-molfreesolv dataset GraphRegression", num_graphs=513, save_path=/Users/jimmy/.dgl/ogbg-molfreesolv dataset GraphRegression), Dataset("ogbg-molfreesolv dataset GraphRegression", num_graphs=64, save_path=/Users/jimmy/.dgl/ogbg-molfreesolv dataset GraphRegression), Dataset("ogbg-molfreesolv dataset GraphRegression", num_graphs=65, save_path=/Users/jimmy/.dgl/ogbg-molfreesolv dataset GraphRegression)]
```