### PR TITLE
Fix #218

### DIFF
--- a/glb/dataset.py
+++ b/glb/dataset.py
@@ -39,10 +39,11 @@ class NodeDataset(GLBDataset):
             graph (DGLGraph): A DGL graph.
             task (GLBTask): Node level GLB task config.
         """
+        device = graph.device
         self._g = graph
         self.num_splits = task.num_splits
-        self.node_map = getattr(graph, "node_map", None)
-        self.node_to_class = getattr(graph, "node_to_class", None)
+        self.node_map = getattr(graph, "node_map", None).to(device)
+        self.node_to_class = getattr(graph, "node_to_class", None).to(device)
         self.node_classes = getattr(graph, "node_classes", None)
         super().__init__(graph, task)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Transfer devices of `node_map` and `node_to_class` if needed when initializing `NodeDataset`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixed #218.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
(glb-py36) jimmyzxj@voyager:~/glb/GLB-Repo$ python example.py -g ogbn-mag -t task -d "cuda:0"
> Graph(s) loading takes 6.6436 seconds and uses 1045.7788 MB.
> Task loading takes 0.0153 seconds and uses 6.1889 MB.
> Combining(s) graph and task takes 0.0177 seconds and uses 0.0206 MB.
Dataset("OGBN-MAG dataset. NodeClassification", num_graphs=1, save_path=/home/jimmyzxj/.dgl/OGBN-MAG dataset. NodeClassification)
```