### PR TITLE
Fix #223

### DIFF
--- a/glb/dataset.py
+++ b/glb/dataset.py
@@ -42,8 +42,12 @@ class NodeDataset(GLBDataset):
         device = graph.device
         self._g = graph
         self.num_splits = task.num_splits
-        self.node_map = getattr(graph, "node_map", None).to(device)
-        self.node_to_class = getattr(graph, "node_to_class", None).to(device)
+        self.node_map = getattr(graph, "node_map", None)
+        self.node_to_class = getattr(graph, "node_to_class", None)
+        if self.node_map:
+            self.node_map = self.node_map.to(device)
+        if self.node_to_class:
+            self.node_to_class = self.node_to_class.to(device)
         self.node_classes = getattr(graph, "node_classes", None)
         super().__init__(graph, task)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Check if the NodeDataset contains a heterogeneous graph before transferring the `node_to_class` and `node_map` members to other devices. If not, these members are just `None` and we should not modify them.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fix #223

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
Python 3.6.13 |Anaconda, Inc.| (default, Jun  4 2021, 14:25:59) 
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import glb
>>> glb.dataloading.get_glb_dataset('cora', 'task', 0 )
/home/jimmyzxj/glb/GLB-Repo/datasets/cora/cora.npz already exists. Skip downloading.
/home/jimmyzxj/glb/GLB-Repo/datasets/cora/cora_task.npz already exists. Skip downloading.
CORA dataset.
/home/jimmyzxj/glb/GLB-Repo/datasets/cora/cora.npz already exists. Skip downloading.
/home/jimmyzxj/glb/GLB-Repo/datasets/cora/cora_task.npz already exists. Skip downloading.
Node classification on CORA dataset. Planetoid split.
Dataset("CORA dataset. NodeClassification", num_graphs=1, save_path=/home/jimmyzxj/.dgl/CORA dataset. NodeClassification)
>>> 
```
