### PR TITLE
fix model config

### DIFF
--- a/benchmarks/NodeClassification/configs/GAT.yaml
+++ b/benchmarks/NodeClassification/configs/GAT.yaml
@@ -1,7 +1,8 @@
-num_layers: 2
+num_layers: 1
 num_hidden: 8
 num_heads: 8
 num_out_heads: 2
 residual: False
 dropout: .6
 negative_slope: .2
+

--- a/benchmarks/NodeClassification/configs/GraphSAGE.yaml
+++ b/benchmarks/NodeClassification/configs/GraphSAGE.yaml
@@ -1,4 +1,5 @@
-num_layers: 2
+num_layers: 1
 num_hidden: 8
 dropout: .6
 aggregator_type: gcn
+

--- a/benchmarks/NodeClassification/configs/MoNet.yaml
+++ b/benchmarks/NodeClassification/configs/MoNet.yaml
@@ -1,4 +1,4 @@
-num_layers: 2
+num_layers: 1
 num_hidden: 8
 dropout: .6
 pseudo_dim: 2


### PR DESCRIPTION
The original paper: 1811.05868, set all models to be two layers (input feature --> hidden layer --> output layer). Thus the `num_layers`, which means the number of hidden layers, should be 1.

@GreatSnoopyMe May need to adjust the number of layers of `LINKX` and `MIXHOP` according to his paper.

