### PR TITLE
update gcn, gat and utils

### DIFF
--- a/benchmarks/NodeClassification/models/gat.py
+++ b/benchmarks/NodeClassification/models/gat.py
@@ -30,27 +30,23 @@ class GAT(nn.Module):
         self.num_layers = num_layers
         self.gat_layers = nn.ModuleList()
         self.activation = activation
-        if num_layers > 1:
-            # input projection (no residual)
-            self.gat_layers.append(GATConv(
-                in_dim, num_hidden, heads[0],
-                feat_drop, attn_drop, negative_slope, False, self.activation))
-            # hidden layers
-            for layer in range(1, num_layers-1):
-                # due to multi-head, the in_dim = num_hidden * num_heads
-                self.gat_layers.append(GATConv(num_hidden * heads[layer-1],
-                                               num_hidden, heads[layer],
-                                               feat_drop, attn_drop,
-                                               negative_slope, residual,
-                                               self.activation))
-            # output projection
-            self.gat_layers.append(GATConv(
-                num_hidden * heads[-2], num_classes, heads[-1],
-                feat_drop, attn_drop, negative_slope, residual, None))
-        else:
-            self.gat_layers.append(GATConv(
-                in_dim, num_classes, heads[0],
-                feat_drop, attn_drop, negative_slope, residual, None))
+
+        # input projection (no residual)
+        self.gat_layers.append(GATConv(
+            in_dim, num_hidden, heads[0],
+            feat_drop, attn_drop, negative_slope, False, self.activation))
+        # hidden layers
+        for layer in range(1, num_layers-1):
+            # due to multi-head, the in_dim = num_hidden * num_heads
+            self.gat_layers.append(GATConv(num_hidden * heads[layer-1],
+                                           num_hidden, heads[layer],
+                                           feat_drop, attn_drop,
+                                           negative_slope, residual,
+                                           self.activation))
+        # output projection
+        self.gat_layers.append(GATConv(
+            num_hidden * heads[-2], num_classes, heads[-1],
+            feat_drop, attn_drop, negative_slope, residual, None))
 
     def forward(self, inputs):
         """Forward."""

--- a/benchmarks/NodeClassification/models/gcn.py
+++ b/benchmarks/NodeClassification/models/gcn.py
@@ -26,16 +26,13 @@ class GCN(nn.Module):
         self.layers = nn.ModuleList()
         # input layer
         self.layers.append(GraphConv(in_feats, n_hidden,
-                                     activation=activation,
-                                     norm='none'))
+                                     activation=activation))
         # hidden layers
         for _ in range(n_layers - 1):
             self.layers.append(GraphConv(n_hidden, n_hidden,
-                                         activation=activation,
-                                         norm='none'))
+                                         activation=activation))
         # output layer
-        self.layers.append(GraphConv(n_hidden, n_classes,
-                                     norm='none'))
+        self.layers.append(GraphConv(n_hidden, n_classes))
         self.dropout = nn.Dropout(p=dropout)
 
     def forward(self, features):

--- a/benchmarks/NodeClassification/utils.py
+++ b/benchmarks/NodeClassification/utils.py
@@ -27,7 +27,7 @@ from models.gcn_minibatch import GCNminibatch
 from models.mixhop import MixHop
 from models.linkx import LINKX
 
-Models_need_to_be_densed = ["GraphSAGE", "GAT", "MixHop", "LINKX"]
+Models_need_to_be_densed = ["GCN", "GraphSAGE", "GAT", "MixHop", "LINKX"]
 
 
 def generate_model(args, g, in_feats, n_classes, **model_cfg):


### PR DESCRIPTION
Norm type of GCN is changed from `none` to `default`.
The bug in GAT layer is fixed.
Current version of GCN need to be densed for training, so `utils.py` is modified accordingly.


## How Has This Been Tested?
On the current gcn, we have 4 datasets tuned base on 2000 samples (random search based on https://github.com/Graph-Learning-Benchmarks/GLB-Repo/pull/236). We have the following results:
```
'genius': 0.8342600000000001, 'cora': 0.8123000000000001, 'citeseer': 0.7201000000000001, 'pubmed': 0.7929000000000002
```

Also, a new round of benchmarking is running on the models.


