### PR TITLE
Bug fix: remove `ClassificationTask` from KG task heritage.

### DIFF
--- a/glb/task.py
+++ b/glb/task.py
@@ -192,13 +192,14 @@ class KGEntityPredictionTask(GLBTask):
         super()._load_split(task_dict)
 
 
-class KGRelationPredictionTask(ClassificationTask):
+class KGRelationPredictionTask(GLBTask):
     """Knowledge graph relation prediction task."""
 
     def __init__(self, task_dict, pwd, device="cpu"):
         """Rename num_relations to num_classes."""
         # REVIEW - only supports runtime sampling for now
         self.sample_runtime = True
+        self.num_relations = task_dict["num_relations"]
         super().__init__(task_dict, pwd, device)
 
     def _load(self, task_dict):


### PR DESCRIPTION
Bug fix: remove `ClassificationTask` from KG task heritage to prevent `test_dataloading.py` failure.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Keep `num_relations` key in knowledge graph tasks, and create standalone (inherit base class only) task configuration for KG tasks to prevent conflict with `test_dataloading.py`.
