### PR TITLE
Fix GraphClassification bug

### DIFF
--- a/gli/graph.py
+++ b/gli/graph.py
@@ -121,7 +121,8 @@ def _get_multi_graph(data, device="cpu", name=None):
 
     for attr in data["Graph"]:
         for i, graph in enumerate(graphs):
-            setattr(graph, attr, data["Graph"][attr][i])  # Graph-level features
+            # Graph-level features
+            setattr(graph, attr, data["Graph"][attr][i])
 
     return graphs
 

--- a/gli/graph.py
+++ b/gli/graph.py
@@ -121,7 +121,7 @@ def _get_multi_graph(data, device="cpu", name=None):
 
     for attr in data["Graph"]:
         for i, graph in enumerate(graphs):
-            setattr(graph, attr, data["Graph"][attr])  # Graph-level features
+            setattr(graph, attr, data["Graph"][attr][i])  # Graph-level features
 
     return graphs
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, the graph dataset loading will assign all graph labels to each single graph. This pr fixed this bug to the expected behavior: only assign the corresponding graph label to a given graph.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixed #271

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->