### PR TITLE
remove redundant folders in examples

### DIFF
--- a/examples/ogbg-molhiv/urls.json
+++ b/examples/ogbg-molhiv/urls.json
@@ -1,4 +1,0 @@
-{
-    "ogbg-molhiv.npz": "https://drive.google.com/uc?id=1u6FIj4xaDhnxNZriOajUFzcxlExzXGvz&export=download",
-    "ogbg-molhiv_task.npz": "https://drive.google.com/uc?id=1FGONYlU3WSWFX5AuzDdOD7c3cQWZDLAA&export=download"
-}

--- a/examples/ogbl-collab/urls.json
+++ b/examples/ogbl-collab/urls.json
@@ -1,5 +1,0 @@
-{
-    "ogbl-collab.npz": "https://drive.google.com/uc?id=1dbx-lBrH8iI3O1UY_34GevLG3mYuclIZ&export=download",
-    "ogbl-collab_task_runtime_sampling.npz": "https://drive.google.com/uc?id=1WasBUF4VGzJ8mJ1THJv9E2UN6QQ8ZbJN&export=download",
-    "ogbl-collab_task_prestore_neg.npz": "https://drive.google.com/uc?id=1pNaDiAgHO2UT5X1EWcW4wtNFYdGHLrQa&export=download"
-}

--- a/examples/ogbn-mag/urls.json
+++ b/examples/ogbn-mag/urls.json
@@ -1,4 +1,0 @@
-{
-    "ogbn-mag.npz": "https://drive.google.com/uc?id=1GTmX8qS9xDY4g1RNAA9tGEsXlxj-I2Tf&export=download",
-    "ogbn-mag_task.npz": "https://drive.google.com/uc?id=1nfUA-rf7xXWzJ77SAPnTmNeQ9VrJsoM9&export=download"
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove the redundant folders in `/examples` that are mistakenly introduced when merging a conflict (in #253).
