### PR TITLE
change instructions on Uploading GLI Data Files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,7 @@ where `<name>` is the dataset name and `<task_type>` is one of the given tasks d
 
 ### Uploading GLI Data Files
 
-Please upload the npz or npy files referred in `metadata.json` or `task_<task_type>.json` to this website: [Upload data files for GLI-Repo
-](https://www.dropbox.com/request/pQVRimU7vd8aSTwtm5SC). The development team will then post the urls in your pull request.
+Please upload the npz or npy files referred in `metadata.json` or `task_<task_type>.json` to a cloud storage platform (e.g., Dropbox or Google Drive), and include the public download links in `urls.json`.
 
 ## Reporting Bugs
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove the deprecated dropbox link in the instructions on Uploading GLI Data Files in CONTRIBUTING.md. Now asking the contributors host data files on their own cloud storage. Later we may figure out a better solution for data uploading.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#293 
