### PR TITLE
fix ogbn proteins class_num bug

### DIFF
--- a/datasets/ogbn-proteins/task_node_classification_1.json
+++ b/datasets/ogbn-proteins/task_node_classification_1.json
@@ -6,7 +6,7 @@
         "Edge/EdgeFeature"
     ],
     "target": "Node/NodeLabel",
-    "num_classes":1,
+    "num_classes":2,
     "train_set": {
         "file": "ogbn-proteins_task.npz",
         "key": "train"


### PR DESCRIPTION
As titled, it should be 2, rather than 1