### PR TITLE
Update Makefile to allow test single dataset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ help:
 	@echo "  test:     run all tests (pystyle, pylint, pytest). Stop on failure."
 	@echo "  pystyle:  run pycodestyle and pydocstyle tests."
 	@echo "  pylint:   run pylint."
-	@echo "  pytest:   run pytests with all tests."
+	@echo "  pytest:   run pytests on all datasets by default."
+	@echo "            run pytest on a single dataset by arg DATASET."
+	@echo "            e.g., make pytest DATASET=cora"
 	@echo "  donwload: download and preprocess all data files (npz)."
 
 setup:
@@ -35,10 +37,18 @@ pylint: logs
 	-pylint ${PYTHON_FILES} --rcfile .pylintrc | tee logs/pylint.log
 
 pytest: logs
+ifndef DATASET
 	-pytest -v tests/ | tee logs/pytest.log
+else
+	mkdir -p temp
+	@echo $$DATASET > temp/changed_datasets
+	-pytest -v tests/ | tee logs/pytest.log
+	rm temp/changed_datasets
+	rmdir temp
+endif
 
 download:
 	${PYTHON} tests/preprocess.py
 
 logs:
-	mkdir logs
+	-mkdir logs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Now, `make pytest` can run tests on a single dataset. Example:
```text
$ make pytest DATASET=citeseer
mkdir -p temp
pytest -v tests/ | tee logs/pytest.log
============================= test session starts ==============================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /Users/jimmy/miniforge3/envs/gli/bin/python3.8
cachedir: .pytest_cache
rootdir: /Users/jimmy/Projects/Private/gli
collecting ... collected 6 items

tests/test_data_loading.py::test_data_loading[citeseer] PASSED           [ 16%]
tests/test_files.py::test_if_has_essential_files[citeseer] PASSED        [ 33%]
tests/test_kg_training.py::test_relation_prediction[citeseer] PASSED     [ 50%]
tests/test_kg_training.py::test_entity_prediction[citeseer] PASSED       [ 66%]
tests/test_metadata.py::test_metadata_json_content[citeseer] PASSED      [ 83%]
tests/test_task.py::test_task_json_content[citeseer] PASSED              [100%]
======================== 6 passed, 11 warnings in 0.61s ========================
rm temp/changed_datasets
rmdir temp
```

## Related Issue
#256

## Motivation and Context
We would like contributors to test a single dataset locally. **However, currently, our testing script only supports uploaded datasets (that have urls.json). There is no test API for local files, so contributors still cannot test their own data locally.**

## How Has This Been Tested?
Tested on my own machine.
