### PR TITLE
Fix early stopping

### DIFF
--- a/benchmarks/GraphClassification/train.py
+++ b/benchmarks/GraphClassification/train.py
@@ -107,10 +107,12 @@ def main():
     # loss function, optimizer, scheduler and early stopping
     optimizer = optim.Adam(model.parameters(), lr=0.01)
     scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=50, gamma=0.5)
-    if train_cfg["early_stopping"]:
-        ckpt_name = args.model + "_" + args.dataset + "_"
-        ckpt_name += args.train_cfg
-        stopper = EarlyStopping(ckpt_name=ckpt_name, patience=50)
+
+    ckpt_name = args.model + "_" + args.dataset + "_"
+    ckpt_name += args.train_cfg
+    stopper = EarlyStopping(ckpt_name=ckpt_name,
+                            early_stop=train_cfg["early_stopping"],
+                            patience=50)
 
     if check_binary_classification(args.dataset):
         if label_number > 1:
@@ -149,12 +151,10 @@ def main():
         print(f"Epoch {epoch:05d} | Loss {total_loss / (batch + 1):.4f} | \
                 Train Acc. {train_acc:.4f} | Validation Acc. {valid_acc:.4f}")
 
-        if train_cfg["early_stopping"]:
-            if stopper.step(valid_acc, model):
-                break
+        if stopper.step(valid_acc, model):
+            break
 
-    if train_cfg["early_stopping"]:
-        model.load_state_dict(torch.load(stopper.ckpt_dir))
+    model.load_state_dict(torch.load(stopper.ckpt_dir))
     acc = evaluate(test_loader, device, model, eval_func)
     val_acc = stopper.best_score
     print(f"Test{acc:.4f},Val{val_acc:.4f}")

--- a/benchmarks/GraphClassification/utils.py
+++ b/benchmarks/GraphClassification/utils.py
@@ -140,18 +140,18 @@ class EarlyStopping:
         if self.best_score is None:
             self.best_score = score
             self.save_checkpoint(model)
-        elif self.early_stop_flag:
-            if score < self.best_score:
+        elif score < self.best_score:
+            if self.early_stop_flag:
                 self.counter += 1
                 print(f"EarlyStopping counter: {self.counter}\
                         out of {self.patience}")
                 if self.counter >= self.patience:
                     self.early_stop = True
-            else:
-                self.best_score = score
-                self.save_checkpoint(model)
-                self.counter = 0
-            return self.early_stop
+        else:
+            self.best_score = score
+            self.save_checkpoint(model)
+            self.counter = 0
+        return self.early_stop
 
     def save_checkpoint(self, model):
         """Save model when validation loss decrease."""

--- a/benchmarks/GraphClassification/utils.py
+++ b/benchmarks/GraphClassification/utils.py
@@ -120,12 +120,13 @@ def parse_args():
 class EarlyStopping:
     """Do early stopping."""
 
-    def __init__(self, ckpt_name, patience=50):
+    def __init__(self, ckpt_name, early_stop, patience=50):
         """Init early stopping."""
         self.patience = patience
         self.counter = 0
         self.best_score = None
         self.early_stop = False
+        self.early_stop_flag = early_stop
         self.dir_name = "checkpoints/"
         if ~os.path.isdir(self.dir_name):
             os.makedirs(self.dir_name, exist_ok=True)
@@ -139,17 +140,18 @@ class EarlyStopping:
         if self.best_score is None:
             self.best_score = score
             self.save_checkpoint(model)
-        elif score < self.best_score:
-            self.counter += 1
-            print(f"EarlyStopping counter: {self.counter}\
-                    out of {self.patience}")
-            if self.counter >= self.patience:
-                self.early_stop = True
-        else:
-            self.best_score = score
-            self.save_checkpoint(model)
-            self.counter = 0
-        return self.early_stop
+        elif self.early_stop_flag:
+            if score < self.best_score:
+                self.counter += 1
+                print(f"EarlyStopping counter: {self.counter}\
+                        out of {self.patience}")
+                if self.counter >= self.patience:
+                    self.early_stop = True
+            else:
+                self.best_score = score
+                self.save_checkpoint(model)
+                self.counter = 0
+            return self.early_stop
 
     def save_checkpoint(self, model):
         """Save model when validation loss decrease."""

--- a/benchmarks/NodeClassification/train.py
+++ b/benchmarks/NodeClassification/train.py
@@ -147,10 +147,11 @@ def main():
         raise NotImplementedError(f"Optimizer \
             {train_cfg['optimizer']} is not supported.")
 
-    if train_cfg["early_stopping"]:
-        ckpt_name = args.model + "_" + args.dataset + "_"
-        ckpt_name += args.train_cfg
-        stopper = EarlyStopping(ckpt_name=ckpt_name, patience=50)
+    ckpt_name = args.model + "_" + args.dataset + "_"
+    ckpt_name += args.train_cfg
+    stopper = EarlyStopping(ckpt_name=ckpt_name,
+                            early_stop=train_cfg["early_stopping"],
+                            patience=50)
 
     # use rocauc for binary classification
     if check_binary_classification(args.dataset):
@@ -186,14 +187,12 @@ def main():
               f" ValAcc {val_acc:.4f} | "
               f"ETputs(KTEPS) {n_edges / np.mean(dur) / 1000:.2f}")
 
-        if train_cfg["early_stopping"]:
-            if stopper.step(val_acc, model):
-                break
+        if stopper.step(val_acc, model):
+            break
 
     print()
 
-    if train_cfg["early_stopping"]:
-        model.load_state_dict(torch.load(stopper.ckpt_dir))
+    model.load_state_dict(torch.load(stopper.ckpt_dir))
 
     acc = evaluate(model, features, labels, test_mask, eval_func)
     val_acc = stopper.best_score

--- a/benchmarks/NodeClassification/train.py
+++ b/benchmarks/NodeClassification/train.py
@@ -59,18 +59,18 @@ def main():
                                            args.task_id, device,
                                            args.verbose)
     # check EdgeFeature and multi-modal node features
-    edge_cnt = node_cnt = 0
-    if len(data.features) > 1:
-        for _, element in enumerate(data.features):
-            if "Edge" in element:
-                edge_cnt += 1
-            if "Node" in element:
-                node_cnt += 1
-        if edge_cnt >= 1:
-            raise NotImplementedError("Edge feature is not supported yet.")
-        elif node_cnt >= 2:
-            raise NotImplementedError("Multi-modal node features\
-                                       is not supported yet.")
+    # edge_cnt = node_cnt = 0
+    # if len(data.features) > 1:
+    #     for _, element in enumerate(data.features):
+    #         if "Edge" in element:
+    #             edge_cnt += 1
+    #         if "Node" in element:
+    #             node_cnt += 1
+    #     if edge_cnt >= 1:
+    #         raise NotImplementedError("Edge feature is not supported yet.")
+    #     elif node_cnt >= 2:
+    #         raise NotImplementedError("Multi-modal node features\
+    #                                    is not supported yet.")
     g = data[0]
     if train_cfg["to_dense"] or \
        args.model in Models_need_to_be_densed:
@@ -82,9 +82,6 @@ def main():
     # convert to undirected set
     if train_cfg["to_undirected"] or \
        args.dataset in Datasets_need_to_be_undirected:
-        # g = g.to(torch.device("cpu"))
-        # g = dgl.to_bidirected(g, copy_ndata=True)
-        # g = g.to(torch.device("cuda:"+str(device)))
         g = g.to("cpu")
         g = dgl.to_bidirected(g, copy_ndata=True)
         g = g.to(device)
@@ -92,7 +89,7 @@ def main():
     feature_name = re.search(r".*Node/(\w+)", data.features[0]).group(1)
     label_name = re.search(r".*Node/(\w+)", data.target).group(1)
     features = g.ndata[feature_name]
-    labels = g.ndata[label_name]
+    labels = g.ndata[label_name].squeeze()
     train_mask = g.ndata["train_mask"]
     val_mask = g.ndata["val_mask"]
     test_mask = g.ndata["test_mask"]
@@ -104,7 +101,7 @@ def main():
         test_mask = test_mask[:, 0]
 
     # When labels contains -1, modify masks
-    if min(labels) < 0:
+    if labels.min() < 0:
         train_mask = train_mask * (labels >= 0)
         val_mask = val_mask * (labels >= 0)
         test_mask = test_mask * (labels >= 0)
@@ -162,7 +159,6 @@ def main():
             t0 = time.time()
         # forward
         logits = model(features)
-
         loss = loss_fcn(logits[train_mask], labels[train_mask])
 
         optimizer.zero_grad()

--- a/benchmarks/NodeClassification/train_minibatch.py
+++ b/benchmarks/NodeClassification/train_minibatch.py
@@ -136,10 +136,11 @@ def main():
         model.parameters(), lr=train_cfg["lr"],
         weight_decay=train_cfg["weight_decay"])
 
-    if train_cfg["early_stopping"]:
-        ckpt_name = args.model + "_" + args.dataset + "_"
-        ckpt_name += args.train_cfg
-        stopper = EarlyStopping(ckpt_name=ckpt_name, patience=50)
+    ckpt_name = args.model + "_" + args.dataset + "_"
+    ckpt_name += args.train_cfg
+    stopper = EarlyStopping(ckpt_name=ckpt_name,
+                            early_stop=train_cfg["early_stopping"],
+                            patience=50)
 
     # initialize graph
     dur = []
@@ -181,14 +182,12 @@ def main():
               f" ValAcc {val_acc:.4f} | "
               f"ETputs(KTEPS) {n_edges / np.mean(dur) / 1000:.2f}")
 
-        if train_cfg["early_stopping"]:
-            if stopper.step(val_acc, model):
-                break
+        if stopper.step(val_acc, model):
+            break
 
     print()
 
-    if train_cfg["early_stopping"]:
-        model.load_state_dict(torch.load(stopper.ckpt_dir))
+    model.load_state_dict(torch.load(stopper.ckpt_dir))
 
     acc = evaluate(model, test_dataloader)
     val_acc = stopper.best_score

--- a/benchmarks/NodeClassification/utils.py
+++ b/benchmarks/NodeClassification/utils.py
@@ -180,12 +180,13 @@ def check_multiple_split(dataset):
 class EarlyStopping:
     """Do early stopping."""
 
-    def __init__(self, ckpt_name, patience=50):
+    def __init__(self, ckpt_name, early_stop, patience=50):
         """Init early stopping."""
         self.patience = patience
         self.counter = 0
         self.best_score = None
         self.early_stop = False
+        self.early_stop_flag = early_stop
         self.dir_name = "checkpoints/"
         if ~os.path.isdir(self.dir_name):
             os.makedirs(self.dir_name, exist_ok=True)
@@ -199,17 +200,18 @@ class EarlyStopping:
         if self.best_score is None:
             self.best_score = score
             self.save_checkpoint(model)
-        elif score < self.best_score:
-            self.counter += 1
-            print(f"EarlyStopping counter: {self.counter}\
-                    out of {self.patience}")
-            if self.counter >= self.patience:
-                self.early_stop = True
-        else:
-            self.best_score = score
-            self.save_checkpoint(model)
-            self.counter = 0
-        return self.early_stop
+        elif self.early_stop_flag:
+            if score < self.best_score:
+                self.counter += 1
+                print(f"EarlyStopping counter: {self.counter}\
+                        out of {self.patience}")
+                if self.counter >= self.patience:
+                    self.early_stop = True
+            else:
+                self.best_score = score
+                self.save_checkpoint(model)
+                self.counter = 0
+            return self.early_stop
 
     def save_checkpoint(self, model):
         """Save model when validation loss decrease."""

--- a/benchmarks/NodeClassification/utils.py
+++ b/benchmarks/NodeClassification/utils.py
@@ -200,18 +200,18 @@ class EarlyStopping:
         if self.best_score is None:
             self.best_score = score
             self.save_checkpoint(model)
-        elif self.early_stop_flag:
-            if score < self.best_score:
+        elif score < self.best_score:
+            if self.early_stop_flag:
                 self.counter += 1
                 print(f"EarlyStopping counter: {self.counter}\
                         out of {self.patience}")
                 if self.counter >= self.patience:
                     self.early_stop = True
-            else:
-                self.best_score = score
-                self.save_checkpoint(model)
-                self.counter = 0
-            return self.early_stop
+        else:
+            self.best_score = score
+            self.save_checkpoint(model)
+            self.counter = 0
+        return self.early_stop
 
     def save_checkpoint(self, model):
         """Save model when validation loss decrease."""

--- a/datasets/ogbn-proteins/task_node_classification_1.json
+++ b/datasets/ogbn-proteins/task_node_classification_1.json
@@ -6,7 +6,7 @@
         "Edge/EdgeFeature"
     ],
     "target": "Node/NodeLabel",
-    "num_classes":1,
+    "num_classes":2,
     "train_set": {
         "file": "ogbn-proteins_task.npz",
         "key": "train"


### PR DESCRIPTION
To fix https://github.com/Graph-Learning-Benchmarks/gli/issues/285, when `early_stopping` in `train.yaml` is set to `false`.
In such cases, we still store the model when validation accuracy is highest. But no early stopping is applied.



## How Has This Been Tested?
Training is smooth on both graph classification and node classification
