### PR TITLE
Use safe save/load method for arrays.

### DIFF
--- a/datasets/cora/cora.ipynb
+++ b/datasets/cora/cora.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,49 +78,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.savez_compressed(\"cora.npz\", **data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['node_feats', 'node_class', 'edge', 'node_list', 'edge_list']"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cora = np.load(\"cora.npz\", allow_pickle=True)\n",
-    "cora.files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "116K\tcora.npz\n"
+      "Save all dense arrays to cora.npz, including ['node_class', 'edge', 'node_list', 'edge_list']\n",
+      "Save sparse matrix node_feats to cora_node_feats.sparse.npz\n"
      ]
     }
    ],
    "source": [
-    "!du cora.npz -h"
+    "from gli.utils import save_data\n",
+    "save_data(\"cora\", **data)"
    ]
   },
   {
@@ -132,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,25 +115,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Save all dense arrays to cora_task.npz, including ['train', 'val', 'test']\n"
+     ]
+    }
+   ],
    "source": [
     "task_data = {\n",
     "    \"train\": train_set,\n",
     "    \"val\": val_set,\n",
     "    \"test\": test_set\n",
     "}\n",
-    "np.savez_compressed(\"cora_task.npz\", **task_data)"
+    "save_data(\"cora_task\", **task_data)"
    ]
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "c060a5fe1ced4d379d309ec1358bf896d440ce64254413b3c9daccac0d24786c"
-  },
   "kernelspec": {
-   "display_name": "Python 3.9.7 64-bit ('py39': conda)",
+   "display_name": "Python 3.8.13 ('gli')",
    "language": "python",
    "name": "python3"
   },
@@ -175,9 +152,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.13"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "6d44b81210f2b1cc6f5cbf794116c1ed3b756872db4baf49235947e0f03609f1"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/datasets/cora/metadata.json
+++ b/datasets/cora/metadata.json
@@ -6,8 +6,7 @@
                 "description": "Node features of Cora dataset, 1/0-valued vectors.",
                 "type": "int",
                 "format": "SparseTensor",
-                "file": "cora.npz",
-                "key": "node_feats"
+                "file": "cora_node_feats.sparse.npz"
             },
             "NodeLabel": {
                 "description": "Node labels of Cora dataset, int ranged from 1 to 7.",

--- a/datasets/cora/urls.json
+++ b/datasets/cora/urls.json
@@ -1,4 +1,5 @@
 {
-    "cora.npz": "https://drive.google.com/uc?id=1t8ZJlB-qIYGbQUJtouRLX0PVY-XtPQJ8&export=download",
-    "cora_task.npz": "https://drive.google.com/uc?id=1IEKQ1rt7D5rT9bI7fOrGURvQ2JWIEUXQ&export=download"
+    "cora.npz": "https://www.dropbox.com/s/ba056xftgqp8uo4/cora.npz",
+    "cora_node_feats.sparse.npz": "https://www.dropbox.com/s/uqf6oszbgltkmd0/cora_node_feats.sparse.npz",
+    "cora_task.npz": "https://www.dropbox.com/s/zvpdfg6hz6r9pbn/cora_task.npz"
 }

--- a/gli/graph.py
+++ b/gli/graph.py
@@ -13,7 +13,7 @@ import torch
 import numpy as np
 from tqdm import tqdm
 
-from .utils import file_reader, sparse_to_torch
+from .utils import sparse_to_torch, load_data
 
 
 def read_gli_graph(metadata_path: os.PathLike, device="cpu", verbose=True):
@@ -220,16 +220,14 @@ def _dict_depth(d):
 
 def _dfs_read_file(pwd, d, device="cpu"):
     """Read file efficiently."""
-    data = _dfs_read_file_helper(pwd, d, device)
-    return data
+    return _dfs_read_file_helper(pwd, d, device)
 
 
 def _dfs_read_file_helper(pwd, d, device="cpu"):
     """Read file recursively (helper of `_dfs_read_file`)."""
     if "file" in d:
         path = os.path.join(pwd, d["file"])
-        array = file_reader.get(path, d.get("key"), device)
-        return array
+        return load_data(path, d.get("key"), device)
 
     empty_keys = []
     for k in d:

--- a/gli/task.py
+++ b/gli/task.py
@@ -7,7 +7,7 @@ from typing import List
 
 import torch
 
-from gli.utils import file_reader
+from gli.utils import load_data
 
 SUPPORTED_TASK_TYPES = [
     "NodeClassification", "NodeRegression", "GraphClassification",
@@ -105,10 +105,10 @@ class GLITask:
                     assert key[-4:] == "FOLD", "split key not ending with FOLD"
                     this_fold_key = f"{key[:-4]}{fold}"
                     self.split[dataset_].append(
-                        file_reader.get(path, this_fold_key, self.device))
+                        load_data(path, this_fold_key, self.device))
                     # can be a list of mask tensors or index tensors
             else:
-                self.split[dataset_] = file_reader.get(path, key, self.device)
+                self.split[dataset_] = load_data(path, key, self.device)
                 # can be a mask tensor or an index tensor
 
 
@@ -230,7 +230,7 @@ class TimeDependentLinkPredictionTask(LinkPredictionTask):
                 filename = task_dict[neg_idx]["file"]
                 key = task_dict[neg_idx].get("key")
                 path = os.path.join(self.pwd, filename)
-                indices = file_reader.get(path, key, self.device)
+                indices = load_data(path, key, self.device)
                 setattr(self, neg_idx, indices)
 
 

--- a/gli/utils.py
+++ b/gli/utils.py
@@ -330,9 +330,8 @@ def _to_dense(graph: dgl.DGLGraph, feat=None, group=None, is_node=True):
         graph.ndata[feat][group] = _sparse_to_dense_safe(
             graph.ndata[feat][group])
     else:
-        raise NotImplementedError(
-            "Both feat and group should be provided for"
-            " heterograph.")
+        raise NotImplementedError("Both feat and group should be provided for"
+                                  " heterograph.")
 
     return graph
 
@@ -390,3 +389,30 @@ def to_dense(graph: dgl.DGLGraph):
         return node_to_dense(edge_to_dense(graph))
     else:
         raise NotImplementedError("to_dense only works for homograph.")
+
+
+def save_npz(dataset_name, **kwargs):
+    """Save arrays into numpy binary formats.
+    
+    Dense arrays (numpy) will be saved in the below format as a single file:
+        <dataset_name>.npz
+    Sparse arrays (scipy) will be saved in the below format individually:
+        <dataset_name>_<key>.sparse.npz
+    """
+    dense_arrays = {}
+    sparse_arrays = {}
+    for key, matrix in kwargs.items():
+        if sp.issparse(matrix):
+            sparse_arrays[key] = matrix
+        elif isinstance(matrix, np.ndarray):
+            dense_arrays[key] = matrix
+
+    # Save numpy arrays into a single file
+    np.savez_compressed(f"{dataset_name}.npz", **dense_arrays)
+    print("Save all dense arrays to",
+          f"{dataset_name}.npz, including {list(dense_arrays.keys())}")
+    
+    # Save scipy sparse matrices into different files by keys
+    for key, matrix in sparse_arrays.items():
+        sp.save_npz(f"{dataset_name}_{key}.sparse.npz", matrix)
+        print("Save sparse matrix", key, "to", f"{dataset_name}_{key}.sparse.npz")

--- a/gli/utils.py
+++ b/gli/utils.py
@@ -176,7 +176,7 @@ def load_data(path, key=None, device="cpu"):
     # Dense arrays file with a key
     raw = np.load(path, allow_pickle=False)
     assert key is not None
-    array = raw.get(key)    
+    array = raw.get(key)
     raw.close()
     return torch.from_numpy(array).to(device)
 
@@ -359,7 +359,7 @@ def to_dense(graph: dgl.DGLGraph):
 
 def save_data(prefix, **kwargs):
     """Save arrays into numpy binary formats.
-    
+
     Dense arrays (numpy) will be saved in the below format as a single file:
         <prefix>.npz
     Sparse arrays (scipy) will be saved in the below format individually:
@@ -377,7 +377,7 @@ def save_data(prefix, **kwargs):
     np.savez_compressed(f"{prefix}.npz", **dense_arrays)
     print("Save all dense arrays to",
           f"{prefix}.npz, including {list(dense_arrays.keys())}")
-    
+
     # Save scipy sparse matrices into different files by keys
     for key, matrix in sparse_arrays.items():
         sp.save_npz(f"{prefix}_{key}.sparse.npz", matrix)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,7 +3,7 @@ import pytest
 import os
 import json
 from utils import find_datasets, check_if_metadata_json, \
-    _is_hetero_graph, find_datasets_abs_path
+    _is_hetero_graph, _is_sparse_npz, find_datasets_abs_path
 
 
 def check_essential_keys_metadata_json(dic):
@@ -43,6 +43,11 @@ def check_essential_keys_metadata_json_homogeneous(dic):
                         "key",
                         ]:
             if dic["data"]["Node"][key].get(sub_key, None) is None:
+                if sub_key == "key":
+                    if _is_sparse_npz(dic["data"]["Node"].get("file", "")):
+                        # Scipy sparse file only stores one array
+                        # No `key` is needed.
+                        continue
                 missing_keys.append("data: Node: " + key + ": " + sub_key)
 
     for sup_key in ["Edge", "Graph"]:
@@ -51,6 +56,10 @@ def check_essential_keys_metadata_json_homogeneous(dic):
                             "key",
                             ]:
                 if dic["data"][sup_key][key].get(sub_key, None) is None:
+                    if sub_key == "key":
+                        if _is_sparse_npz(
+                              dic["data"][sup_key][key].get("file", "")):
+                            continue
                     missing_keys.append("data: " + sup_key + ": " +
                                         key + ": " + sub_key)
 
@@ -80,6 +89,11 @@ def check_essential_keys_metadata_json_heterogeneous(dic):
                                     ]:
                     if dic["data"]["Node"][key][sub_key].get(sub_sub_key,
                                                              None) is None:
+                        if sub_sub_key == "key":
+                            if _is_sparse_npz(
+                                  dic["data"]["Node"][key][sub_key].get(
+                                    "file", "")):
+                                continue
                         missing_keys.append("data: Node: " +
                                             key + ": " + sub_key +
                                             ": " + sub_sub_key)
@@ -96,6 +110,11 @@ def check_essential_keys_metadata_json_heterogeneous(dic):
                                     ]:
                     if dic["data"]["Edge"][key][sub_key].get(sub_sub_key,
                                                              None) is None:
+                        if sub_sub_key == "key":
+                            if _is_sparse_npz(
+                                  dic["data"]["Edge"][key][sub_key].get(
+                                    "file", "")):
+                                continue
                         missing_keys.append("data: Edge: " + key + ": " +
                                             sub_key + ": " + sub_sub_key)
     return missing_keys

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -44,7 +44,8 @@ def check_essential_keys_metadata_json_homogeneous(dic):
                         ]:
             if dic["data"]["Node"][key].get(sub_key, None) is None:
                 if sub_key == "key":
-                    if _is_sparse_npz(dic["data"]["Node"].get("file", "")):
+                    if _is_sparse_npz(
+                          dic["data"]["Node"][key].get("file", "")):
                         # Scipy sparse file only stores one array
                         # No `key` is needed.
                         continue

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -150,3 +150,8 @@ def load_config_file(path):
             return parsed_yaml
         except yaml.YAMLError as exc:
             print(exc)
+
+
+def _is_sparse_npz(filename):
+    """Check if the npz file is storing a scipy sparse array."""
+    return filename.endswith(".sparse.npz")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request
- Add a utility function `save_date` for users to safely save multiple arrays.
```python
from gli.utils import save_data
data = {
    "node_feats": node_feats,
    "node_class": node_class,
    "edge": edge,
    "node_list": node_list,
    "edge_list": edge_list
}
save_data("cora", **data)
```
```
Save all dense arrays to cora.npz, including ['node_class', 'edge', 'node_list', 'edge_list']
Save sparse matrix node_feats to cora_node_feats.sparse.npz
```
- Update the utility function `load_data` for gli to safely load array(s) from file.
- Update cora as an example for dataset saving and loading.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#264 
Fix #266 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/Graph-Learning-Benchmarks/gli/issues/266#issuecomment-1258898577

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I only tested this feature on the aforementioned updated version of cora dataset. This PR will not pass unless all npz files are updated accordingly.
