### PR TITLE
Fix pytest failure when deleting dataset

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,6 +21,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install -e .
+        pip install pyyaml
     - name: Get changed files using defaults
       id: changed-files
       uses: tj-actions/changed-files@v23.1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install -e .
-        pip install pyyaml
     - name: Get changed files using defaults
       id: changed-files
       uses: tj-actions/changed-files@v23.1
@@ -36,6 +35,7 @@ jobs:
         then
           dataset_list=()
           for path in ${{ steps.changed-files.outputs.all_changed_and_modified_files }}; do
+              if [ ! -d "$path" ]; then continue; fi
               dataset=$(echo $path | grep "datasets" | sed -r 's/datasets\/([_a-zA-Z0-9-]+)\/.*/\1/')
               if [ -z "$dataset" ]; then continue; fi
               if [[ ! " ${dataset_list[*]} " =~ " ${dataset} " ]]; then

--- a/datasets/ogbn-proteins/task_node_classification_1.json
+++ b/datasets/ogbn-proteins/task_node_classification_1.json
@@ -6,7 +6,7 @@
         "Edge/EdgeFeature"
     ],
     "target": "Node/NodeLabel",
-    "num_classes":1,
+    "num_classes":2,
     "train_set": {
         "file": "ogbn-proteins_task.npz",
         "key": "train"


### PR DESCRIPTION
This is to fix https://github.com/Graph-Learning-Benchmarks/gli/issues/278, where pytest fails when a dataset is deleted.

The correctness can be verified by https://github.com/Graph-Learning-Benchmarks/gli/pull/328. We delete `cora` completely and testing is successful.

After this PR is merged, https://github.com/Graph-Learning-Benchmarks/gli/pull/328 will be closed.
