### PR TITLE
Add warning in `save_data()`

### DIFF
--- a/gli/utils.py
+++ b/gli/utils.py
@@ -372,6 +372,10 @@ def save_data(prefix, **kwargs):
             sparse_arrays[key] = matrix
         elif isinstance(matrix, np.ndarray):
             dense_arrays[key] = matrix
+        elif matrix is None:
+            continue
+        else:
+            raise TypeError(f"Unsupported format {type(matrix)}.")
 
     # Save numpy arrays into a single file
     np.savez_compressed(f"{prefix}.npz", **dense_arrays)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When users try to save data that are not in supported format (`np.ndarray` or `scipy.sparse_matrix`), gli raises a TypeError.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#364

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, gli does not save data in unsupported formats. Rather, it just ignores such a case. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test on my own machine.