### PR TITLE
Ignore reading non numeric array

### DIFF
--- a/gli/utils.py
+++ b/gli/utils.py
@@ -176,9 +176,14 @@ def load_data(path, key=None, device="cpu"):
     # Dense arrays file with a key
     raw = np.load(path, allow_pickle=False)
     assert key is not None
-    array = raw.get(key)
+    array: np.ndarray = raw.get(key)
     raw.close()
-    return torch.from_numpy(array).to(device)
+    try:
+        torch_tensor = torch.from_numpy(array)
+    except TypeError:
+        print(f"Non supported np.ndarray type {array.dtype}.")
+        return None
+    return torch_tensor.to(device)
 
 
 def sparse_to_torch(sparse_array: sp.spmatrix,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`load_data()` will ignore non-numerical arrays.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#381