### PR TITLE
change pytest ubuntu version to 20.04

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Got pytest error as follows

```
[199](https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/3671611809/jobs/6207122144#step:3:200)
Error: Version 3.6 with arch x64 not found
[200](https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/3671611809/jobs/6207122144#step:3:201)
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

Possibly due to `ubuntu-latest` switched to 22.04 recently. This PR changes `ubuntu-latest` to `ubuntu-20.04`
