### PR TITLE
Fix pylint test error due to deprecated feature

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -436,6 +436,6 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=StandardError,
-                       Exception,
-                       BaseException
+overgeneral-exceptions=builtins.StandardError,
+                       builtins.Exception,
+                       builtins.BaseException

--- a/gli/utils.py
+++ b/gli/utils.py
@@ -100,7 +100,7 @@ def download_file_from_google_drive(g_url: str,
     os.makedirs(root, exist_ok=True)
 
     url = "https://drive.google.com/uc"
-    params = dict(id=file_id, export="download")
+    params = {"id": file_id, "export": "download"}
     with requests.Session() as session:
         response = session.get(url, params=params, stream=True)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As titled.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/4109270662/jobs/7091223333

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://stackoverflow.com/questions/75370815/pylint-specifying-exception-names-in-the-overgeneral-exceptions-option-without

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my local machine.