### PR TITLE
Upgrade GitHub Action python version to 3.7

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install dependencies
         run: |
           # pip install sphinx sphinx_rtd_theme
-          pip install -e ".[full]"
+          pip install -e ".[doc]"
       - name: Sphinx build
         run: |
           sphinx-build docs/source _build

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6"]
+        python-version: ["3.7"]
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates our GitHub Action's python version to 3.7. In specific, only the pytest workflow is affected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/Graph-Learning-Benchmarks/gli/pull/420#issuecomment-1477202977

## How Has This Been Tested?
Test online by GitHub Action.
