### PR TITLE
Add a function interface for saving a new dataset to replace  metadata.json

### DIFF
--- a/gli/io.py
+++ b/gli/io.py
@@ -3,6 +3,7 @@ from gli.utils import save_data
 import numpy as np
 import scipy.sparse as sp
 
+
 class Attributes(object):
     def __init__(
         self,
@@ -29,6 +30,7 @@ class Attributes(object):
                 self.format = "Tensor"
             elif sp.issparse(data):
                 self.format = "SparseTensor"
+
     def to_dict(self, loc : dict()):
         if not loc:
             return None
@@ -42,22 +44,25 @@ class Attributes(object):
         info.update({"file" : loc})
         info.update({"key" : self.key})
         return {self.name : info}
+    
     def get_key(self, prefix):
         # heterogeneous
         # self.key = "%s/%s" % (prefix, self.name)
         if not self.key:
-            self.key = f"{prefix}_{self.name}" #TODO:
+            #TODO:
+            self.key = f"{prefix}_{self.name}" 
         return self.key
 
+
 def save_graph(name,
-    edges,
-    node_list,
-    edge_list=None,
-    node_attrs=[],
-    edge_attrs=[],
-    graph_attrs=[],
-    citation=None,
-    is_heterogeneous = False,
+               edges,
+               node_list,
+               edge_list=None,
+               node_attrs=[],
+               edge_attrs=[],
+               graph_attrs=[],
+               citation=None,
+               is_heterogeneous = False,
 ):
     # save data
     data = dict()
@@ -70,12 +75,14 @@ def save_graph(name,
     if edge_list is not None:
         data.update({"edge_list" : edge_list})
     key_to_loc = save_data(f"{name}__graph", **data)
+
     # save metadata.json
     def _attrs_to_dict(attrs):
         d = dict()
         for a in attrs:
             d.update(a.to_dict(key_to_loc.get(a.key)))
         return d
+    
     node = _attrs_to_dict(node_attrs)
     edge = {"_Edge": key_to_loc.get("edge")}
     edge.update(_attrs_to_dict(edge_attrs))
@@ -84,10 +91,10 @@ def save_graph(name,
         graph.update({"_EdgeList": key_to_loc.get("edge_list")})
     graph.update(_attrs_to_dict(graph_attrs))
     metadata = {"description": "%s dataset" % name,
-         "Node": node,
-         "Edge": edge,
-         "Graph": graph,
-         "citation": citation,
-         "is_heterogeneous": is_heterogeneous}
+                "Node": node,
+                "Edge": edge,
+                "Graph": graph,
+                "citation": citation,
+                "is_heterogeneous": is_heterogeneous}
     with open("metadata.json", "w") as f:
         json.dump(metadata, f, indent=4)

--- a/gli/io.py
+++ b/gli/io.py
@@ -1,0 +1,94 @@
+import json
+from gli.utils import save_data
+import numpy as np
+import scipy.sparse as sp
+
+class Attributes(object):
+    def __init__(
+        self,
+        name,
+        description=None,
+        data=None,
+        data_type=None,
+        data_format=None
+    ):
+        self.name = name
+        self.description = description
+        self.data = data
+        self.key = None
+        print("data_type: ", data_type)
+        print(type(data))
+        if type is not None:
+            self.type = data_type
+        else:
+            self.type = type(data)
+        if data_format is not None:
+            self.format = data_format
+        else:
+            if isinstance(data, np.ndarray):
+                self.format = "Tensor"
+            elif sp.issparse(data):
+                self.format = "SparseTensor"
+    def to_dict(self, loc : dict()):
+        if not loc:
+            return None
+        info = dict()
+        if self.description:
+            info.update({"description" : self.description})
+        # if self.type:
+        info.update({"type" : self.type})
+        # if self.format:
+        info.update({"format" : self.format})
+        info.update({"file" : loc})
+        info.update({"key" : self.key})
+        return {self.name : info}
+    def get_key(self, prefix):
+        # heterogeneous
+        # self.key = "%s/%s" % (prefix, self.name)
+        if not self.key:
+            self.key = f"{prefix}_{self.name}" #TODO:
+        return self.key
+
+def save_graph(name,
+    edges,
+    node_list,
+    edge_list=None,
+    node_attrs=[],
+    edge_attrs=[],
+    graph_attrs=[],
+    citation=None,
+    is_heterogeneous = False,
+):
+    # save data
+    data = dict()
+    for e in edge_attrs:
+        data.update({e.get_key("Edge") : e.data})
+    for n in node_attrs:
+        data.update({n.get_key("Node") : n.data})
+    data.update({"edge" : edges})
+    data.update({"node_list" : node_list})
+    if edge_list is not None:
+        data.update({"edge_list" : edge_list})
+    key_to_loc = save_data(f"{name}__graph", **data)
+    # save metadata.json
+    def _attrs_to_dict(attrs):
+        d = dict()
+        for a in attrs:
+            d.update(a.to_dict(key_to_loc.get(a.key)))
+        return d
+    node = _attrs_to_dict(node_attrs)
+    edge = {"_Edge" : key_to_loc.get("edge")}
+    edge.update(_attrs_to_dict(edge_attrs))
+    graph = {"_NodeList" : key_to_loc.get("node_list")}
+    if edge_list is not None:
+        graph.update({"_EdgeList" : key_to_loc.get("edge_list")})
+    graph.update(_attrs_to_dict(graph_attrs))
+    metadata = {"description" : "%s dataset" % name,
+         "Node" : node,
+         "Edge" : edge,
+         "Graph" : graph,
+         "citation" : citation,
+         "is_heterogeneous" : is_heterogeneous}
+    with open("metadata.json","w") as f:
+        json.dump(metadata,f, indent = 4)
+        

--- a/gli/io.py
+++ b/gli/io.py
@@ -31,26 +31,26 @@ class Attributes(object):
             elif sp.issparse(data):
                 self.format = "SparseTensor"
 
-    def to_dict(self, loc : dict()):
+    def to_dict(self, loc: dict()):
         if not loc:
             return None
         info = dict()
         if self.description:
-            info.update({"description" : self.description})
+            info.update({"description": self.description})
         # if self.type:
-        info.update({"type" : self.type})
+        info.update({"type": self.type})
         # if self.format:
-        info.update({"format" : self.format})
-        info.update({"file" : loc})
-        info.update({"key" : self.key})
-        return {self.name : info}
-    
+        info.update({"format": self.format})
+        info.update({"file": loc})
+        info.update({"key": self.key})
+        return {self.name: info}
+
     def get_key(self, prefix):
         # heterogeneous
         # self.key = "%s/%s" % (prefix, self.name)
         if not self.key:
-            #TODO:
-            self.key = f"{prefix}_{self.name}" 
+            # TODO:
+            self.key = f"{prefix}_{self.name}"
         return self.key
 
 
@@ -62,18 +62,18 @@ def save_graph(name,
                edge_attrs=[],
                graph_attrs=[],
                citation=None,
-               is_heterogeneous = False,
+               is_heterogeneous=False,
 ):
     # save data
     data = dict()
     for e in edge_attrs:
-        data.update({e.get_key("Edge") : e.data})
+        data.update({e.get_key("Edge"): e.data})
     for n in node_attrs:
-        data.update({n.get_key("Node") : n.data})
-    data.update({"edge" : edges})
-    data.update({"node_list" : node_list})
+        data.update({n.get_key("Node"): n.data})
+    data.update({"edge": edges})
+    data.update({"node_list": node_list})
     if edge_list is not None:
-        data.update({"edge_list" : edge_list})
+        data.update({"edge_list": edge_list})
     key_to_loc = save_data(f"{name}__graph", **data)
 
     # save metadata.json
@@ -82,7 +82,7 @@ def save_graph(name,
         for a in attrs:
             d.update(a.to_dict(key_to_loc.get(a.key)))
         return d
-    
+
     node = _attrs_to_dict(node_attrs)
     edge = {"_Edge": key_to_loc.get("edge")}
     edge.update(_attrs_to_dict(edge_attrs))

--- a/gli/io.py
+++ b/gli/io.py
@@ -77,18 +77,17 @@ def save_graph(name,
             d.update(a.to_dict(key_to_loc.get(a.key)))
         return d
     node = _attrs_to_dict(node_attrs)
-    edge = {"_Edge" : key_to_loc.get("edge")}
+    edge = {"_Edge": key_to_loc.get("edge")}
     edge.update(_attrs_to_dict(edge_attrs))
-    graph = {"_NodeList" : key_to_loc.get("node_list")}
+    graph = {"_NodeList": key_to_loc.get("node_list")}
     if edge_list is not None:
-        graph.update({"_EdgeList" : key_to_loc.get("edge_list")})
+        graph.update({"_EdgeList": key_to_loc.get("edge_list")})
     graph.update(_attrs_to_dict(graph_attrs))
-    metadata = {"description" : "%s dataset" % name,
-         "Node" : node,
-         "Edge" : edge,
-         "Graph" : graph,
-         "citation" : citation,
-         "is_heterogeneous" : is_heterogeneous}
-    with open("metadata.json","w") as f:
-        json.dump(metadata,f, indent = 4)
-        
+    metadata = {"description": "%s dataset" % name,
+         "Node": node,
+         "Edge": edge,
+         "Graph": graph,
+         "citation": citation,
+         "is_heterogeneous": is_heterogeneous}
+    with open("metadata.json", "w") as f:
+        json.dump(metadata, f, indent=4)

--- a/gli/io.py
+++ b/gli/io.py
@@ -62,8 +62,7 @@ def save_graph(name,
                edge_attrs=[],
                graph_attrs=[],
                citation=None,
-               is_heterogeneous=False,
-):
+               is_heterogeneous=False):
     # save data
     data = dict()
     for e in edge_attrs:


### PR DESCRIPTION
Add a function interface for saving a new dataset to replace  metadata.json

## Description
New interface for users to both save the graph and generate `metadata.json`



## Motivation and Context
Help users to generate correct `metadata.json`

## How Has This Been Tested?
Use cora dataset for test.
```python
from gli.io import save_graph, Attributes
# save_data("cora", **data)
save_graph(
    "cora",
    edge,
    node_list,
    edge_list=edge_list,
    node_attrs=[Attributes("NodeFeature",
                           description="Node features of Cora dataset, 1/0-valued vectors.",
                           data=node_feats,
                           data_type="int",
                           ),
                Attributes("NodeLabel",
                           description="Node labels of Cora dataset, int ranged from 1 to 7.",
                           data=node_class,
                           data_type="int",
                           ),
                ],
    edge_attrs=[],
    graph_attrs=[],
    citation="@inproceedings{yang2016revisiting,\ntitle={Revisiting semi-supervised learning with graph embeddings},\nauthor={Yang, Zhilin and Cohen, William and Salakhudinov, Ruslan},\nbooktitle={International conference on machine learning},\npages={40--48},\nyear={2016},\norganization={PMLR}\n}",
    is_heterogeneous = False
)
```
The corresponding test result is 
```json
{
    "description": "cora dataset",
    "Node": {
        "NodeFeature": {
            "description": "Node features of Cora dataset, 1/0-valued vectors.",
            "type": "int",
            "format": "SparseTensor",
            "file": {
                "file": "cora__graph__Node_NodeFeature__7032c9c380d1889061dcbbcd76b8c427.sparse.npz"
            },
            "key": "Node_NodeFeature"
        },
        "NodeLabel": {
            "description": "Node labels of Cora dataset, int ranged from 1 to 7.",
            "type": "int",
            "format": "Tensor",
            "file": {
                "file": "cora__graph__499e577d2533c2e69dd170791ffb6522.npz",
                "key": "Node_NodeLabel"
            },
            "key": "Node_NodeLabel"
        }
    },
    "Edge": {
        "_Edge": {
            "file": "cora__graph__499e577d2533c2e69dd170791ffb6522.npz",
            "key": "edge"
        }
    },
    "Graph": {
        "_NodeList": {
            "file": "cora__graph__499e577d2533c2e69dd170791ffb6522.npz",
            "key": "node_list"
        },
        "_EdgeList": {
            "file": "cora__graph__499e577d2533c2e69dd170791ffb6522.npz",
            "key": "edge_list"
        }
    },
    "citation": "@inproceedings{yang2016revisiting,\ntitle={Revisiting semi-supervised learning with graph embeddings},\nauthor={Yang, Zhilin and Cohen, William and Salakhudinov, Ruslan},\nbooktitle={International conference on machine learning},\npages={40--48},\nyear={2016},\norganization={PMLR}\n}",
    "is_heterogeneous": false
}
```
