### PR TITLE
fix missing _load in LinkPredictionTask

### DIFF
--- a/gli/task.py
+++ b/gli/task.py
@@ -239,6 +239,9 @@ class LinkPredictionTask(GLITask):
         self.sample_runtime = self.val_neg is None
         super().__init__(task_dict, pwd)
 
+    def _load(self, task_dict):
+        self._load_split(task_dict)
+
 
 class KGEntityPredictionTask(GLITask):
     """Knowledge graph entity prediction task."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The `LinkPredictionTask` class missed the definition of `_load()` function. This PR fixed it.

