### PR TITLE
Add url download from server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,9 @@ docs/source/_build
 docs/html
 docs/doctrees
 docs/build
+
+# PyTorch model checkpoints
+**/checkpoints
+
+# Global URL
+**/global_urls.json

--- a/gli/config.py
+++ b/gli/config.py
@@ -5,3 +5,4 @@ ROOT_PATH = dirname(dirname(realpath(__file__)))
 WARNING_DENSE_SIZE = 1e9
 DATASET_PATH = join(expanduser("~"), ".gli/datasets")
 GLOBAL_FILE_URL = "https://www.jiaqima.com/gli/global_urls.json"
+SERVER_IP = "http://34.211.28.138"

--- a/gli/utils.py
+++ b/gli/utils.py
@@ -336,13 +336,13 @@ def download_data(dataset: str, verbose=False):
 
     # First, get urls from EC2
     data_file_url_dict = {}
-    flag = False  # Whether all urls are retrieved from server
+    url_retrieval_success = True  # Whether all urls are retrieved from server
     for data_file in data_files:
         data_file_url_dict[data_file] = _get_url_from_server(data_file)
         if data_file_url_dict[data_file] is None:
-            flag = True
+            url_retrieval_success = False
 
-    if flag:
+    if not url_retrieval_success:
         # Second, check the local urls.json file.
         url_file = os.path.join(data_dir, "urls.json")
         if os.path.exists(url_file):

--- a/gli/utils.py
+++ b/gli/utils.py
@@ -18,7 +18,8 @@ import torch
 from torch.utils.model_zoo import tqdm
 
 import gli.config
-from gli import DATASET_PATH, GLOBAL_FILE_URL, ROOT_PATH, WARNING_DENSE_SIZE, SERVER_IP
+from gli import DATASET_PATH, GLOBAL_FILE_URL, ROOT_PATH, WARNING_DENSE_SIZE,\
+    SERVER_IP
 
 
 def get_available_datasets():
@@ -293,19 +294,21 @@ def _find_data_files_from_json_files(data_dir):
 
     return data_files
 
-def _get_url_from_server(data_file:str):
-    """Get url for a specific data file from server."""
 
+def _get_url_from_server(data_file: str):
+    """Get url for a specific data file from server."""
     resp = requests.request("GET",
                             SERVER_IP +
                             "/api/get-url/" +
-                            data_file).json()
+                            data_file,
+                            timeout=5).json()
     if resp["message_type"] == "error":
         return None
     elif resp["message_type"] == "url":
         return resp["content"]
-    else :
+    else:
         return None
+
 
 def download_data(dataset: str, verbose=False):
     """Download dependent data of a configuration (metadata/task) file.
@@ -333,7 +336,7 @@ def download_data(dataset: str, verbose=False):
 
     # First, get urls from EC2
     data_file_url_dict = {}
-    flag = False # Whether all urls are retrieved from server
+    flag = False  # Whether all urls are retrieved from server
     for data_file in data_files:
         data_file_url_dict[data_file] = _get_url_from_server(data_file)
         if data_file_url_dict[data_file] is None:
@@ -347,7 +350,8 @@ def download_data(dataset: str, verbose=False):
                 url_dict = json.load(fp)
         else:
             # Thrid, try to download and check the global_urls.json file.
-            global_url_file = os.path.join(get_local_data_dir(), "global_urls.json")
+            global_url_file = os.path.join(
+                get_local_data_dir(), "global_urls.json")
             _download(GLOBAL_FILE_URL, global_url_file, verbose=verbose)
             if os.path.exists(global_url_file):
                 with open(global_url_file, "r", encoding="utf-8") as fp:

--- a/gli/utils.py
+++ b/gli/utils.py
@@ -18,7 +18,7 @@ import torch
 from torch.utils.model_zoo import tqdm
 
 import gli.config
-from gli import DATASET_PATH, GLOBAL_FILE_URL, ROOT_PATH, WARNING_DENSE_SIZE
+from gli import DATASET_PATH, GLOBAL_FILE_URL, ROOT_PATH, WARNING_DENSE_SIZE, SERVER_IP
 
 
 def get_available_datasets():
@@ -293,6 +293,19 @@ def _find_data_files_from_json_files(data_dir):
 
     return data_files
 
+def _get_url_from_server(data_file:str):
+    """Get url for a specific data file from server."""
+
+    resp = requests.request("GET",
+                            SERVER_IP +
+                            "/api/get-url/" +
+                            data_file).json()
+    if resp["message_type"] == "error":
+        return None
+    elif resp["message_type"] == "url":
+        return resp["content"]
+    else :
+        return None
 
 def download_data(dataset: str, verbose=False):
     """Download dependent data of a configuration (metadata/task) file.
@@ -318,28 +331,35 @@ def download_data(dataset: str, verbose=False):
             print("All data files already exist. Skip downloading.")
         return
 
-    # First, check the local urls.json file.
-    url_file = os.path.join(data_dir, "urls.json")
-    if os.path.exists(url_file):
-        with open(url_file, "r", encoding="utf-8") as fp:
-            url_dict = json.load(fp)
-    else:
-        # Second, try to download and check the global_urls.json file.
-        global_url_file = os.path.join(data_dir, "global_urls.json")
-        _download(GLOBAL_FILE_URL, global_url_file, verbose=verbose)
-        if os.path.exists(global_url_file):
-            with open(global_url_file, "r", encoding="utf-8") as fp:
+    # First, get urls from EC2
+    data_file_url_dict = {}
+    flag = False # Whether all urls are retrieved from server
+    for data_file in data_files:
+        data_file_url_dict[data_file] = _get_url_from_server(data_file)
+        if data_file_url_dict[data_file] is None:
+            flag = True
+
+    if flag:
+        # Second, check the local urls.json file.
+        url_file = os.path.join(data_dir, "urls.json")
+        if os.path.exists(url_file):
+            with open(url_file, "r", encoding="utf-8") as fp:
                 url_dict = json.load(fp)
         else:
-            raise FileNotFoundError("cannot find urls.json and failed to "
-                                    "download global_urls.json.")
+            # Thrid, try to download and check the global_urls.json file.
+            global_url_file = os.path.join(get_local_data_dir(), "global_urls.json")
+            _download(GLOBAL_FILE_URL, global_url_file, verbose=verbose)
+            if os.path.exists(global_url_file):
+                with open(global_url_file, "r", encoding="utf-8") as fp:
+                    url_dict = json.load(fp)
 
     # Get urls for all required data files.
-    data_file_url_dict = {}
     for data_file in data_files:
-        if data_file not in url_dict:
-            raise ValueError(f"cannot find url for {data_file}.")
-        data_file_url_dict[data_file] = url_dict[data_file]
+        if data_file not in data_file_url_dict:
+            if data_file in url_dict[data_file]:
+                data_file_url_dict[data_file] = url_dict[data_file]
+            else:
+                raise FileNotFoundError(f"cannot find url for {data_file}.")
 
     for data_file_name, url in data_file_url_dict.items():
         data_file_path = os.path.join(data_dir, data_file_name)


### PR DESCRIPTION
Now `download_data()` in `gli.utils` gets url from server first.

## Related Issue
#425 

## How Has This Been Tested?
Deleted `urls.json` of cifar dataset, and the url is still downloaded succesfully from EC2 server.
