### PR TITLE
Use new io for dataset saving

### DIFF
--- a/datasets/cora/cora.ipynb
+++ b/datasets/cora/cora.ipynb
@@ -40,6 +40,7 @@
     "import torch\n",
     "import scipy.sparse as sparse\n",
     "from dgl.data import CoraGraphDataset\n",
+    "\n",
     "dataset = CoraGraphDataset()\n",
     "graph = dataset[0]"
    ]
@@ -55,44 +56,116 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(10556, 2)\n"
+     ]
+    }
+   ],
    "source": [
-    "# cora_feat\n",
+    "# node features\n",
     "node_feats = sparse.csr_matrix(graph.ndata[\"feat\"].numpy())\n",
-    "# cora_class\n",
+    "# node labels\n",
     "node_class = graph.ndata[\"label\"].numpy()  # (2708,)\n",
-    "# cora_edge\n",
+    "# edge list\n",
     "edge = torch.stack(graph.edges()).numpy().T\n",
-    "# cora only has 1 single connected graph\n",
-    "node_list = np.ones((1, graph.num_nodes()))  # (1, 2708)\n",
-    "edge_list = np.ones((1, graph.num_edges()))  # (1, 10556)\n",
-    "\n",
-    "data = {\n",
-    "    \"node_feats\": node_feats,\n",
-    "    \"node_class\": node_class,\n",
-    "    \"edge\": edge,\n",
-    "    \"node_list\": node_list,\n",
-    "    \"edge_list\": edge_list\n",
-    "}"
+    "print(edge.shape)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gli.io import save_graph, Attribute\n",
+    "\n",
+    "node_attrs = [\n",
+    "    Attribute(\n",
+    "        \"NodeFeature\",\n",
+    "        node_feats,\n",
+    "        \"Node features of Cora dataset, 1/0-valued vectors.\",\n",
+    "        \"int\",\n",
+    "        \"SparseTensor\",\n",
+    "    ),\n",
+    "    Attribute(\n",
+    "        \"NodeLabel\",\n",
+    "        node_class,\n",
+    "        \"Node labels of Cora dataset, int ranged from 1 to 7.\",\n",
+    "        \"int\",\n",
+    "        \"Tensor\",\n",
+    "    )\n",
+    "]\n",
+    "\n",
+    "metadata = save_graph(\n",
+    "    name=\"cora\",\n",
+    "    edge=edge,\n",
+    "    num_nodes=graph.num_nodes(),\n",
+    "    node_attrs=node_attrs,\n",
+    "    description=\"CORA dataset.\",\n",
+    "    cite=\n",
+    "    \"@inproceedings{yang2016revisiting,\\ntitle={Revisiting semi-supervised learning with graph embeddings},\\nauthor={Yang, Zhilin and Cohen, William and Salakhudinov, Ruslan},\\nbooktitle={International conference on machine learning},\\npages={40--48},\\nyear={2016},\\norganization={PMLR}\\n}\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The metadata.json and graph data (.npz files) is now saved in the current directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Save all dense arrays to cora.npz, including ['node_class', 'edge', 'node_list', 'edge_list']\n",
-      "Save sparse matrix node_feats to cora_node_feats.sparse.npz\n"
+      "{\n",
+      "  \"description\": \"CORA dataset.\",\n",
+      "  \"data\": {\n",
+      "    \"Node\": {\n",
+      "      \"NodeFeature\": {\n",
+      "        \"description\": \"Node features of Cora dataset, 1/0-valued vectors.\",\n",
+      "        \"type\": \"int\",\n",
+      "        \"format\": \"SparseTensor\",\n",
+      "        \"file\": \"cora__graph__Node_NodeFeature__7032c9c380d1889061dcbbcd76b8c427.sparse.npz\"\n",
+      "      },\n",
+      "      \"NodeLabel\": {\n",
+      "        \"description\": \"Node labels of Cora dataset, int ranged from 1 to 7.\",\n",
+      "        \"type\": \"int\",\n",
+      "        \"format\": \"Tensor\",\n",
+      "        \"file\": \"cora__graph__6c912909fa18eff10797210ea5e485fe.npz\",\n",
+      "        \"key\": \"Node_NodeLabel\"\n",
+      "      }\n",
+      "    },\n",
+      "    \"Edge\": {\n",
+      "      \"_Edge\": {\n",
+      "        \"file\": \"cora__graph__6c912909fa18eff10797210ea5e485fe.npz\",\n",
+      "        \"key\": \"Edge_Edge\"\n",
+      "      }\n",
+      "    },\n",
+      "    \"Graph\": {\n",
+      "      \"_NodeList\": {\n",
+      "        \"file\": \"cora__graph__Graph_NodeList__23bbef862fd6037395412eb03b4e1d9c.sparse.npz\"\n",
+      "      }\n",
+      "    }\n",
+      "  },\n",
+      "  \"citation\": \"@inproceedings{yang2016revisiting,\\ntitle={Revisiting semi-supervised learning with graph embeddings},\\nauthor={Yang, Zhilin and Cohen, William and Salakhudinov, Ruslan},\\nbooktitle={International conference on machine learning},\\npages={40--48},\\nyear={2016},\\norganization={PMLR}\\n}\",\n",
+      "  \"is_heterogeneous\": false\n",
+      "}\n"
      ]
     }
    ],
    "source": [
-    "from gli.utils import save_data\n",
-    "save_data(\"cora\", **data)"
+    "# Print metadata\n",
+    "print(json.dumps(metadata, indent=2))"
    ]
   },
   {
@@ -104,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,24 +188,152 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gli.io import save_task_node_classification\n",
+    "\n",
+    "task_data = save_task_node_classification(\n",
+    "    name=\"cora\",\n",
+    "    description=\"Node classification on CORA dataset. Planetoid split.\",\n",
+    "    feature=[\"Node/NodeFeature\"],\n",
+    "    target=\"Node/NodeLabel\",\n",
+    "    num_classes=7,\n",
+    "    train_set=train_set,\n",
+    "    val_set=val_set,\n",
+    "    test_set=test_set,\n",
+    "    task_id=\"1\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The task data (.json and .npz files) is now saved in the current directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Save all dense arrays to cora_task.npz, including ['train', 'val', 'test']\n"
+      "{\n",
+      "  \"description\": \"Node classification on CORA dataset. Planetoid split.\",\n",
+      "  \"type\": \"NodeClassification\",\n",
+      "  \"feature\": [\n",
+      "    \"Node/NodeFeature\"\n",
+      "  ],\n",
+      "  \"target\": \"Node/NodeLabel\",\n",
+      "  \"num_classes\": 7,\n",
+      "  \"train_set\": {\n",
+      "    \"file\": \"cora__task_node_classification_1__41e167258678b585872679839ce9c40f.npz\",\n",
+      "    \"key\": \"train_set\"\n",
+      "  },\n",
+      "  \"val_set\": {\n",
+      "    \"file\": \"cora__task_node_classification_1__41e167258678b585872679839ce9c40f.npz\",\n",
+      "    \"key\": \"val_set\"\n",
+      "  },\n",
+      "  \"test_set\": {\n",
+      "    \"file\": \"cora__task_node_classification_1__41e167258678b585872679839ce9c40f.npz\",\n",
+      "    \"key\": \"test_set\"\n",
+      "  }\n",
+      "}\n"
      ]
     }
    ],
    "source": [
-    "task_data = {\n",
-    "    \"train\": train_set,\n",
-    "    \"val\": val_set,\n",
-    "    \"test\": test_set\n",
-    "}\n",
-    "save_data(\"cora_task\", **task_data)"
+    "print(json.dumps(task_data, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test loading the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CORA dataset.\n",
+      "Node classification on CORA dataset. Planetoid split.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jimmy/Projects/Private/gli/gli/utils.py:254: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:56.)\n",
+      "  return torch.sparse_csr_tensor(crow_indices,\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Graph(num_nodes=2708, num_edges=10556,\n",
+       "      ndata_schemes={'NodeFeature': Scheme(shape=(1433,), dtype=torch.float32), 'NodeLabel': Scheme(shape=(), dtype=torch.int64), 'train_mask': Scheme(shape=(), dtype=torch.bool), 'val_mask': Scheme(shape=(), dtype=torch.bool), 'test_mask': Scheme(shape=(), dtype=torch.bool)}\n",
+       "      edata_schemes={})"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from gli.dataloading import read_gli_graph, read_gli_task, combine_graph_and_task\n",
+    "\n",
+    "g = read_gli_graph(\"./metadata.json\")\n",
+    "t = read_gli_task(\"./task_node_classification_1.json\")\n",
+    "data = combine_graph_and_task(g, t)\n",
+    "data[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After adding LICENSE and README.md, the dataset directory will be the following."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1;36m.\u001b[00m\n",
+      "├── LICENSE\n",
+      "├── README.md\n",
+      "├── cora.ipynb\n",
+      "├── cora__graph__6c912909fa18eff10797210ea5e485fe.npz\n",
+      "├── cora__graph__Graph_NodeList__23bbef862fd6037395412eb03b4e1d9c.sparse.npz\n",
+      "├── cora__graph__Node_NodeFeature__7032c9c380d1889061dcbbcd76b8c427.sparse.npz\n",
+      "├── cora__task_node_classification_1__41e167258678b585872679839ce9c40f.npz\n",
+      "├── metadata.json\n",
+      "└── task_node_classification_1.json\n",
+      "\n",
+      "0 directories, 9 files\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tree ."
    ]
   }
  ],

--- a/datasets/cora/metadata.json
+++ b/datasets/cora/metadata.json
@@ -6,30 +6,25 @@
                 "description": "Node features of Cora dataset, 1/0-valued vectors.",
                 "type": "int",
                 "format": "SparseTensor",
-                "file": "cora_node_feats.sparse.npz"
+                "file": "cora__graph__Node_NodeFeature__7032c9c380d1889061dcbbcd76b8c427.sparse.npz"
             },
             "NodeLabel": {
                 "description": "Node labels of Cora dataset, int ranged from 1 to 7.",
                 "type": "int",
                 "format": "Tensor",
-                "file": "cora.npz",
-                "key": "node_class"
+                "file": "cora__graph__6c912909fa18eff10797210ea5e485fe.npz",
+                "key": "Node_NodeLabel"
             }
         },
         "Edge": {
             "_Edge": {
-                "file": "cora.npz",
-                "key": "edge"
+                "file": "cora__graph__6c912909fa18eff10797210ea5e485fe.npz",
+                "key": "Edge_Edge"
             }
         },
         "Graph": {
             "_NodeList": {
-                "file": "cora.npz",
-                "key": "node_list"
-            },
-            "_EdgeList": {
-                "file": "cora.npz",
-                "key": "edge_list"
+                "file": "cora__graph__Graph_NodeList__23bbef862fd6037395412eb03b4e1d9c.sparse.npz"
             }
         }
     },

--- a/datasets/cora/task_node_classification_1.json
+++ b/datasets/cora/task_node_classification_1.json
@@ -7,15 +7,15 @@
     "target": "Node/NodeLabel",
     "num_classes": 7,
     "train_set": {
-        "file": "cora_task.npz",
-        "key": "train"
+        "file": "cora__task_node_classification_1__41e167258678b585872679839ce9c40f.npz",
+        "key": "train_set"
     },
     "val_set": {
-        "file": "cora_task.npz",
-        "key": "val"
+        "file": "cora__task_node_classification_1__41e167258678b585872679839ce9c40f.npz",
+        "key": "val_set"
     },
     "test_set": {
-        "file": "cora_task.npz",
-        "key": "test"
+        "file": "cora__task_node_classification_1__41e167258678b585872679839ce9c40f.npz",
+        "key": "test_set"
     }
 }

--- a/datasets/cora/urls.json
+++ b/datasets/cora/urls.json
@@ -1,5 +1,0 @@
-{
-    "cora.npz": "https://www.dropbox.com/s/ba056xftgqp8uo4/cora.npz",
-    "cora_node_feats.sparse.npz": "https://www.dropbox.com/s/uqf6oszbgltkmd0/cora_node_feats.sparse.npz",
-    "cora_task.npz": "https://www.dropbox.com/s/zvpdfg6hz6r9pbn/cora_task.npz"
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR uses the new helper function `gli.io.save_graph()` and `save_task_node_classification()` to save CORA dataset. These new functions will be encouraged to use rather than saving manually.

## Description
<!--- Describe your changes in detail -->
- cora.ipynb: Replace the old saving method by the aforementioned new functions.
- *.json: Generated automatically.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
First step of #437. We will update other datasets as well in the near future.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We would like to provide a more clean and user-friendly interface for dataset contribution.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally shown in the cora.ipynb.