### PR TITLE
fix pylint version to 2.17.5

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint numpy torch scipy
+        pip install numpy torch scipy
+        pip install --force-reinstall pylint==2.17.5
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py') --rcfile .pylintrc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The new pylint 3.0.1 will cause some weird stack overflow error. This PR modified the pylint.yml file to force the pylint version to be 2.17.5 to temporarily fix the issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Error log of pylint 3.0.1 for future reference:

```
Run pylint $(git ls-files '*.py') --rcfile .pylintrc
Fatal Python error: Cannot recover from stack overflow.
Python runtime state: initialized

Current thread 0x00007f9dd7fa6b[8](https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/6600192279/job/17929956732?pr=455#step:5:9)0 (most recent call first):
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/context.py", line 130 in clone
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/context.py", line 186 in copy_context
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/nodes/node_classes.py", line 5[9](https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/6600192279/job/17929956732?pr=455#step:5:10)8 in _infer
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/decorators.py", line 49 in wrapped
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/decorators.py", line 90 in inner
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/nodes/node_ng.py", line 169 in infer
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 2241 in ancestors
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 2403 in getattr
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 2446 in _get_attribute_from_metaclass
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 2439 in _metaclass_lookup_attribute
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 2415 in getattr
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/nodes/scoped_nodes/scoped_nodes.py", line 25[11](https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/6600192279/job/17929956732?pr=455#step:5:12) in igetattr
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 328 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/astroid/bases.py", line 331 in infer_call_result
  ...
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.18/x64/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pylint/__init__.py", line 34, in run_pylint
    PylintRun(argv or sys.argv[1:])
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pylint/lint/run.py", line 211, in __init__
    linter.check(args)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 679, in check
    check_parallel(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pylint/lint/parallel.py", line [15](https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/6600192279/job/17929956732?pr=455#step:5:16)3, in check_parallel
    for (
  File "/opt/hostedtoolcache/Python/3.8.[18](https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/6600192279/job/17929956732?pr=455#step:5:19)/x64/lib/python3.8/concurrent/futures/process.py", line 484, in _chain_from_iterable_of_lists
    for element in iterable:
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/concurrent/futures/_base.py", line 6[19](https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/6600192279/job/17929956732?pr=455#step:5:20), in result_iterator
    yield fs.pop().result()
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/concurrent/futures/_base.py", line 444, in result
    return self.__get_result()
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/concurrent/futures/_base.py", line [38](https://github.com/Graph-Learning-Benchmarks/gli/actions/runs/6600192279/job/17929956732?pr=455#step:5:39)9, in __get_result
    raise self._exception
concurrent.futures.process.BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending.
Error: Process completed with exit code 1.
```