### PR TITLE
move missing urls.json to warning instead of error

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -42,7 +42,7 @@ def check_file_name(files, dataset_name):
         missing_file_messages_error.append("missing metadata.json")
 
     if not urls_jason_flag:
-        missing_file_messages_error.append("missing urls.json")
+        missing_file_messages_warning.append("missing urls.json")
 
     if not readme_flag:
         missing_file_messages_error.append("missing README.md")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -113,7 +113,7 @@ def check_if_metadata_json(file):
 
 
 def check_if_urls_json(file):
-    """Check if it is metadata.json and correctly named."""
+    """Check if it is urls.json and correctly named."""
     urls_exp = re.compile(r".*urls.*")
     json_exp = re.compile(r"\B.*\.json$")
     if urls_exp.search(file) and json_exp.search(file):
@@ -129,14 +129,14 @@ def check_if_readme(file):
 
 
 def check_if_license(file):
-    """Check if it is README.md and correctly named."""
+    """Check if it is LICENSE and correctly named."""
     if file == "LICENSE":
         return True
     return False
 
 
 def check_if_converting_code(file, dataset):
-    """Check if it is README.md and correctly named."""
+    """Check if it is .ipynb or .py file and correctly named."""
     if file in (f"{dataset}.ipynb", file == f"{dataset}.py"):
         return True
     return False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`urls.json` will be deprecated. This PR moves missing `urls.json` from error to warning in `test_files.py`. 

This PR also fixed a few docstring typos in `tests/utils.py`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

See #425
