### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ git clone https://github.com/Graph-Learning-Benchmarks/gli.git
 cd gli
 pip install -e .
 ```
+MacOS users may need to install `wget` in terminal to avoid `FileNotFoundError: [Errno 2] No such file or directory: 'wget'`. Run `brew install wget` to solve this problem (you should have [homebrew](https://brew.sh/) installed first)
 
 To test the installation, run the following command:
 


### PR DESCRIPTION
Add solution to an unreported problem

<!--- Provide a general summary of your changes in the Title above -->

## Description
When I follow the instructions to install GLI in my Macbook M1Pro 13.4. , I encountered `FileNotFoundError: [Errno 2] No such file or directory: 'wget'`,  it seems that macOS systems do not come with wget, but we can install it with homebrew.
<!--- Describe your changes in detail -->
I added some additional info in the installation part of README file.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After installing wget, no error messages occur

## Screenshots (if appropriate):
