### PR TITLE
temporary fix predict_tail missing in existing datasets

### DIFF
--- a/gli/task.py
+++ b/gli/task.py
@@ -251,7 +251,11 @@ class KGEntityPredictionTask(GLITask):
         # REVIEW - only supports runtime sampling for now
         self.sample_runtime = True
         self.num_relations = task_dict["num_relations"]
-        self.predict_tail = task_dict["predict_tail"]
+        # REVIEW - Making predict_tail optional to be compatible
+        # with existing datasets. Should be removed when datasets
+        # are updated with the new save_task helper function.
+        self.predict_tail = task_dict.get(
+            "predict_tail", True)
         super().__init__(task_dict, pwd, device)
 
     def _load(self, task_dict):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

PR #450 added the `predict_tail` parameter in the `KGEntityPrediction ` task. However, the existing KG datasets task configuration files did not have this parameter, which leads to an error in data loading. This PR temporarily makes this parameter as optional and sets the default value to be True. This change should be reverted back after all the datasets are updated with the save_task helper function. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested loading FB13.

## Screenshots (if appropriate):

<img width="1121" alt="image" src="https://github.com/Graph-Learning-Benchmarks/gli/assets/5397179/e34a8795-22d7-42be-a0f3-fa242f0b0b91">
