### PR TITLE
add note for wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ git clone https://github.com/Graph-Learning-Benchmarks/gli.git
 cd gli
 pip install -e .
 ```
+> *Note: [wget](https://www.gnu.org/software/wget/) is required to download datasets.*
 
 To test the installation, run the following command:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`wget` is called during downloading data files, which leads to an error for users who don't have `wget` installed. This PR adds a note in README to remind the user about the dependency on `wget`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
There is a relevant PR #467 but somehow the commit got stuck there. Using this new PR to replace it.
