### PR TITLE
Change default int dtype to np.int64 in `gli.io`

### DIFF
--- a/gli/io/edge_task.py
+++ b/gli/io/edge_task.py
@@ -118,9 +118,9 @@ def save_task_link_prediction(name,
         "feature": feature,
     }
     data_dict = {
-        "train_set": np.array(train_set),
-        "val_set": np.array(val_set),
-        "test_set": np.array(test_set)
+        "train_set": np.array(train_set, dtype=np.int64),
+        "val_set": np.array(val_set, dtype=np.int64),
+        "test_set": np.array(test_set, dtype=np.int64),
     }
     if val_neg is not None:
         data_dict["val_neg"] = val_neg

--- a/gli/io/utils.py
+++ b/gli/io/utils.py
@@ -245,9 +245,9 @@ def save_task_reg_or_cls(task_type,
     if train_set is not None:
         # Save the task data files, i.e., the data splits in this task.
         data_dict = {
-            "train_set": np.array(train_set),
-            "val_set": np.array(val_set),
-            "test_set": np.array(test_set)
+            "train_set": np.array(train_set, dtype=np.int64),
+            "val_set": np.array(val_set, dtype=np.int64),
+            "test_set": np.array(test_set, dtype=np.int64)
         }
         key_to_loc = save_data(f"{name}__task_{task_str}_{task_id}",
                                save_dir=save_dir,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When saving datatset splits like `train_set`, we now use dtype of np.int64 for an consistent behavior with torch, as torch indexing requires long tensor for some version.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This pr fixes #474

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This pr is motivated by the issue found in #472.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See automated tests.

